### PR TITLE
docs: add RTK token optimization section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ docs/              Assembly guide, demo scenarios, architecture
 - FastAPI + WebRTC — Remote dashboard
 - OpenCV — Camera pipeline
 
+## Token Optimization (Experimental)
+
+This repo includes [RTK](https://github.com/rtk-ai/rtk) config for 60-90% LLM token savings during agentic coding sessions.
+
+```bash
+make setup_rtk    # install RTK binary
+rtk init -g       # activate CC PreToolUse hook (run outside CC session)
+rtk gain --graph  # view token savings
+```
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary

- Add experimental RTK section to README with `make setup_rtk`, `rtk init -g`, `rtk gain --graph`
- Links to https://github.com/rtk-ai/rtk

Generated with Claude <noreply@anthropic.com>