### PR TITLE
test: close deferred test improvements (#54)

### DIFF
--- a/tests/dashboard/test_dashboard.py
+++ b/tests/dashboard/test_dashboard.py
@@ -63,3 +63,44 @@ class TestDashboardWebSocket:
             ws.send_text(json.dumps({"command": "target_well", "well": "A1"}))
             resp = json.loads(ws.receive_text())
             assert "status" in resp
+
+
+class TestWebSocketErrors:
+    """WebSocket error handling paths."""
+
+    def test_malformed_json_returns_error(self) -> None:
+        """Sending non-JSON text returns an error, doesn't crash."""
+        with TestClient(app) as client, client.websocket_connect("/ws") as ws:
+            ws.send_text("not valid json {{{")
+            resp = json.loads(ws.receive_text())
+            assert "error" in resp
+            assert "invalid JSON" in resp["error"]
+
+    def test_unknown_command_succeeds(self) -> None:
+        """Unknown commands don't crash — they just return status."""
+        with TestClient(app) as client, client.websocket_connect("/ws") as ws:
+            ws.send_text(json.dumps({"command": "nonexistent_command"}))
+            resp = json.loads(ws.receive_text())
+            assert "status" in resp
+
+    def test_empty_command_succeeds(self) -> None:
+        """Missing command key returns status without error."""
+        with TestClient(app) as client, client.websocket_connect("/ws") as ws:
+            ws.send_text(json.dumps({"no_command_key": True}))
+            resp = json.loads(ws.receive_text())
+            assert "status" in resp
+
+
+class TestStatusEndpoint:
+    """REST status endpoint."""
+
+    def test_get_status_returns_expected_keys(self) -> None:
+        """GET /api/status returns mode, e_stopped, connected, arm_ids."""
+        with TestClient(app) as client:
+            resp = client.get("/api/status")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "mode" in data
+            assert "e_stopped" in data
+            assert "connected" in data
+            assert "arm_ids" in data

--- a/tests/so101/test_camera.py
+++ b/tests/so101/test_camera.py
@@ -1,5 +1,11 @@
 """Tests for camera pipeline — must work without cv2/camera hardware."""
 
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
 import pytest
 from pydantic import ValidationError
 
@@ -77,3 +83,103 @@ class TestCameraPipeline:
         pipeline = CameraPipeline([CameraConfig(name="test", device_index=0)])
         pipeline.stop()
         pipeline.stop()
+
+
+def _make_mock_cv2() -> MagicMock:
+    """Create a mock cv2 module with required constants."""
+    mock_cv2 = MagicMock()
+    mock_cv2.CAP_PROP_FRAME_WIDTH = 3
+    mock_cv2.CAP_PROP_FRAME_HEIGHT = 4
+    mock_cv2.CAP_PROP_FPS = 5
+    return mock_cv2
+
+
+class TestCameraPipelineWithMockCV2:
+    """Tests covering cv2-dependent paths with mocked VideoCapture."""
+
+    def test_start_opens_cameras(self) -> None:
+        """start() calls VideoCapture and sets properties for each camera."""
+        mock_cv2 = _make_mock_cv2()
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = True
+        mock_cv2.VideoCapture.return_value = mock_cap
+
+        with patch.dict(sys.modules, {"cv2": mock_cv2}):
+            pipeline = CameraPipeline([CameraConfig(name="test", device_index=0)])
+            pipeline.start()
+            mock_cv2.VideoCapture.assert_called_once_with(0)
+            assert "test" in pipeline._captures
+
+    def test_start_skips_failed_camera(self) -> None:
+        """start() skips cameras that fail to open."""
+        mock_cv2 = _make_mock_cv2()
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = False
+        mock_cv2.VideoCapture.return_value = mock_cap
+
+        with patch.dict(sys.modules, {"cv2": mock_cv2}):
+            pipeline = CameraPipeline([CameraConfig(name="test", device_index=0)])
+            pipeline.start()
+            assert pipeline._captures == {}
+
+    def test_stop_releases_captures(self) -> None:
+        """stop() calls release() on all open captures."""
+        mock_cv2 = _make_mock_cv2()
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = True
+        mock_cv2.VideoCapture.return_value = mock_cap
+
+        with patch.dict(sys.modules, {"cv2": mock_cv2}):
+            pipeline = CameraPipeline([CameraConfig(name="test", device_index=0)])
+            pipeline.start()
+            pipeline.stop()
+            mock_cap.release.assert_called_once()
+            assert pipeline._captures == {}
+
+    def test_get_frame_returns_array(self) -> None:
+        """get_frame() returns the frame when capture succeeds."""
+        mock_cv2 = _make_mock_cv2()
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = True
+        mock_cap.read.return_value = (True, np.zeros((480, 640, 3), dtype=np.uint8))
+        mock_cv2.VideoCapture.return_value = mock_cap
+
+        with patch.dict(sys.modules, {"cv2": mock_cv2}):
+            pipeline = CameraPipeline([CameraConfig(name="test", device_index=0)])
+            pipeline.start()
+            frame = pipeline.get_frame("test")
+            assert frame is not None
+            assert frame.shape == (480, 640, 3)
+
+    def test_get_frame_returns_none_on_read_failure(self) -> None:
+        """get_frame() returns None when cap.read() fails."""
+        mock_cv2 = _make_mock_cv2()
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = True
+        mock_cap.read.return_value = (False, None)
+        mock_cv2.VideoCapture.return_value = mock_cap
+
+        with patch.dict(sys.modules, {"cv2": mock_cv2}):
+            pipeline = CameraPipeline([CameraConfig(name="test", device_index=0)])
+            pipeline.start()
+            assert pipeline.get_frame("test") is None
+
+    def test_get_frames_aggregates_multiple(self) -> None:
+        """get_frames() returns dict of all active camera frames."""
+        fake = np.zeros((480, 640, 3), dtype=np.uint8)
+        mock_cv2 = _make_mock_cv2()
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = True
+        mock_cap.read.return_value = (True, fake)
+        mock_cv2.VideoCapture.return_value = mock_cap
+
+        with patch.dict(sys.modules, {"cv2": mock_cv2}):
+            configs = [
+                CameraConfig(name="a", device_index=0),
+                CameraConfig(name="b", device_index=2),
+            ]
+            pipeline = CameraPipeline(configs)
+            pipeline.start()
+            frames = pipeline.get_frames()
+            assert "a" in frames
+            assert "b" in frames

--- a/tests/so101/test_pipette.py
+++ b/tests/so101/test_pipette.py
@@ -5,7 +5,7 @@ never internal state like _current_fill or _volume_to_steps.
 """
 
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
@@ -246,3 +246,41 @@ class TestPipetteProperties:
         p.connect()
         p.aspirate(volume)
         p.dispense(volume)
+
+
+class TestMultiStepPipetteProperties:
+    """Multi-step Hypothesis property tests for pipette volume accounting."""
+
+    @given(
+        volumes=st.lists(
+            st.floats(min_value=0.1, max_value=50.0),
+            min_size=1,
+            max_size=5,
+        ),
+    )
+    @settings(max_examples=50)
+    def test_multi_aspirate_dispense_returns_to_zero(self, volumes: list[float]) -> None:
+        """Any sequence of aspirate+dispense pairs leaves fill at zero."""
+        p = DigitalPipette(PipetteConfig(serial_port="/dev/ttyUSB_MISSING", max_volume_ul=200.0))
+        p.connect()
+        for vol in volumes:
+            p.aspirate(vol)
+            p.dispense(vol)
+        # After all pairs, dispensing anything should fail (fill is 0)
+        with pytest.raises(ValueError, match="exceeds current fill"):
+            p.dispense(0.1)
+
+    @given(volume=st.floats(min_value=0.1, max_value=200.0))
+    def test_aspirate_at_exact_capacity(self, volume: float) -> None:
+        """Aspirating any valid volume up to max succeeds."""
+        p = DigitalPipette(PipetteConfig(serial_port="/dev/ttyUSB_MISSING", max_volume_ul=200.0))
+        p.connect()
+        p.aspirate(volume)  # should not raise
+
+    @given(volume=st.floats(min_value=200.01, max_value=1000.0))
+    def test_aspirate_over_capacity_always_raises(self, volume: float) -> None:
+        """Aspirating beyond max always raises, regardless of amount."""
+        p = DigitalPipette(PipetteConfig(serial_port="/dev/ttyUSB_MISSING", max_volume_ul=200.0))
+        p.connect()
+        with pytest.raises(ValueError, match="exceeds max"):
+            p.aspirate(volume)

--- a/tests/so101/test_xz_gantry.py
+++ b/tests/so101/test_xz_gantry.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from so101.xz_gantry import XZGantry, XZGantryConfig
@@ -139,3 +141,24 @@ class TestXZGantryTeaching:
         gantry.save_config(str(out))
         data = yaml.safe_load(out.read_text())  # type: ignore[union-attr]
         assert "taught" in data["positions"]
+
+
+class TestXZGantryProperties:
+    """Hypothesis property tests for gantry position management."""
+
+    @given(
+        x=st.floats(min_value=0.0, max_value=200.0),
+        y=st.floats(min_value=0.0, max_value=100.0),
+    )
+    def test_teach_and_move_roundtrip(self, x: float, y: float) -> None:
+        """Any taught position can be moved to without error."""
+        config = XZGantryConfig(
+            serial_port="/dev/ttyUSB_MISSING",
+            positions={},
+        )
+        g = XZGantry(config)
+        g.connect()
+        g._current_x = x
+        g._current_z = y
+        g.teach_position("test_pos")
+        g.move_to_position("test_pos")  # should not raise


### PR DESCRIPTION
## Summary

Closes #54 — addresses the HIGH-value deferred test improvements from the hardening audit.

- **camera.py 56% → 94%**: 6 mock-cv2 tests cover start/stop/get_frame/get_frames paths using `patch.dict(sys.modules)` for the local `import cv2`
- **Dashboard error paths**: 4 tests for malformed JSON, unknown commands, missing command key, GET /api/status
- **Hypothesis property tests**: 4 new tests — multi aspirate+dispense roundtrip, exact capacity, over-capacity rejection, gantry teach-and-move roundtrip

### Numbers

| Metric | Before | After |
|---|---|---|
| Tests | 260 | 274 (+14) |
| Coverage | 87% | 89% |
| camera.py | 56% | 94% |
| server.py | 76% | 79% |

### Deferred (YAGNI per Phase 6 review)

- Fixture consolidation to conftest.py (2-3 line fixtures, file-local is clearer)
- Trivial-test consolidation (minimal savings)
- Stub-mode serial framing (needs real protocol knowledge)
- Remaining impl-spy tests (9 worst already rewritten in #51)

## Test plan

- [x] `make validate` green
- [x] 274 tests pass, 89% coverage (above 80% gate)
- [ ] CI green

Generated with Claude <noreply@anthropic.com>