### PR TITLE
docs: add outlook research for platforms and integrations

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -50,4 +50,15 @@ exclude = [
     # Reference sites — timeout in CI
     "^https://keepachangelog\\.com",
     "^https://semver\\.org",
+    # OpenBuilds — 423 Locked to bots
+    "^https://us\\.openbuilds\\.com",
+    # Autoprotocol — expired SSL (dead project)
+    "^https://www\\.autoprotocol\\.org",
+    # Publisher sites — 403 bot protection
+    "^https://3dprintingindustry\\.com",
+    "^https://journals\\.sagepub\\.com",
+    "^https://pubs\\.acs\\.org",
+    "^https://www\\.hardware-x\\.com",
+    # Reddit — 403 to bots
+    "^https://www\\.reddit\\.com",
 ]

--- a/docs/outlook-ceiling-rail.md
+++ b/docs/outlook-ceiling-rail.md
@@ -1,0 +1,125 @@
+---
+title: "Outlook: Ceiling-Mounted SO-101 on Linear Rail"
+purpose: Feasibility study for inverted SO-101 arm on ceiling gantry — mechanical, software, safety
+authority: Research (INFORMATIONAL — not requirements)
+created: 2026-04-12
+updated: 2026-04-12
+---
+
+# Outlook: Ceiling-Mounted SO-101 on Linear Rail
+
+## Concept
+
+Mount an SO-101 arm inverted from a ceiling-mounted linear rail, freeing the
+entire bench surface. The arm approaches plates, Bento Lab, and reagents from
+above — a natural orientation for pipetting and plate handling.
+
+## Mechanical Feasibility
+
+STS3215 servos (30 kg-cm Pro, 1:345 gear reduction) can handle inverted
+operation, with caveats:
+
+- **Backlash amplification** — gravity pulls through gear backlash zones
+  instead of preloading against them, increasing end-effector positional error.
+- **Sustained holding torque** — base and shoulder servos see continuous load
+  rather than intermittent peaks.
+- **3D-printed joint stress** — PLA/PETG joints designed for compression loads
+  experience tension/hanging loads when inverted. Shoulder joint is the
+  critical failure point.
+
+### Required Modifications
+
+- Metal base plate (aluminum or carbon fiber)
+- Metal shoulder bracket
+- Anti-backlash spring on wrist
+- Secure bolt fasteners replacing press-fits
+- Safety cable/lanyard to rail (redundant fall protection)
+
+## Rail / Gantry Options
+
+| System | Payload | Span | Drive | Cost (1 m) | Python Control |
+|--------|---------|------|-------|------------|----------------|
+| OpenBuilds C-Beam + XLarge cart | ~5 kg | ~2 m | GT2 belt | ~$80-150 | `grbl-streamer` (PyPI) or `pyserial` |
+| igus drylin W | 5-15 kg | 3 m | Belt / lead screw | ~$150-300 | `pymodbus` (ModbusTCP) — no SDK |
+| Bosch Rexroth aluminum | 10+ kg | 3 m+ | Rack-and-pinion | ~$300-600 | PLC integration only |
+
+### Controller Options
+
+| Controller | Interface | Python Package | Notes |
+|------------|-----------|----------------|-------|
+| OpenBuilds BlackBox (Grbl) | USB serial 115200 | `grbl-streamer` | Standard G-code |
+| xPro V5 (FluidNC/ESP32) | USB + WiFi + WebSocket | `pyserial` / `websockets` | YAML config, REST + WebSocket API |
+| ODrive | USB/CAN | `odrive` (PyPI v0.6.11) | Async Python, brushless servo |
+| Moteus | CAN-FD/USB | `moteus` (PyPI v0.3.99) | Async Python, position/velocity/torque |
+| Klipper `manual_stepper` | USB serial | `moonraker-api` (PyPI) | Reuse Klipper stack for single axis |
+
+**Recommendation:** OpenBuilds C-Beam + FluidNC on ESP32. G-code + WebSocket +
+Python via `grbl-streamer`, with community precedent for non-CNC linear motion.
+
+## Workspace Advantages
+
+- Eliminates arm bench footprint entirely.
+- Reach envelope shifts from hemisphere-above-table to downward-facing cone.
+- Collision avoidance simplifies — arm approaches from above, not around
+  obstacles at bench level.
+- Rail axis extends reach beyond a single arm's work envelope.
+
+## Software Impact
+
+- **URDF:** Rotate base link 180 deg around Y-axis. DH parameters unchanged.
+- **Gravity compensation:** Sign flip on virtual displacement direction. See
+  phospho.ai gravity compensation guide for SO-100/101.
+- **IK:** `lerobot-kinematics` (box2ai-robotics) provides IK for SO-100;
+  gravity vector changes but joint geometry is identical.
+- **ACT policies:** Do NOT transfer from tabletop to inverted — joint angle
+  distributions and gravity dynamics differ. Requires new teleoperation
+  demonstrations with arm inverted.
+- **SafetyMonitor:** Existing `JOINT_LIMITS` in `safety.py` apply, but limits
+  should be re-validated for inverted loading.
+- **XZGantry interaction:** Ceiling rail may replace or complement the existing
+  XZ gantry (ceiling = long axis, gantry = cross axis).
+
+## Safety Considerations
+
+- **Falling risk:** Primary hazard. Redundant mechanical fastening (bolts +
+  safety cable). STS3215 servos have no brake — arm free-falls on power loss.
+  Mitigate with spring-return or counterweight.
+- **E-stop:** Must cut servo power AND engage mechanical brake or friction lock.
+- **Vibration:** Belt-driven movement transmits vibration. Pause and settle
+  after gantry moves before pipetting. Rubber isolator mount plate recommended.
+- **Drip risk:** Inverted arm above open containers — any debris/lubricant
+  falls into samples. Use enclosed cable routing and drip shields.
+
+## Precedents
+
+- **Yamaha YK-XGS** — purpose-built ceiling-mount SCARA (industrial).
+- **UR cobots** — officially support floor, wall, and ceiling mounting with
+  software installation angle parameter.
+- **Yaskawa HC cobots** — inverted mounting with 180 deg mount angle setting.
+- No documented SO-101/SO-100 inverted mounting found (this would be novel).
+
+## Quick Refs
+
+| Ref | URL |
+|-----|-----|
+| SO-101 docs (HuggingFace) | <https://huggingface.co/docs/lerobot/so101> |
+| SO-ARM100 (TheRobotStudio) | <https://github.com/TheRobotStudio/SO-ARM100> |
+| Gravity compensation (phospho.ai) | <https://docs.phospho.ai/learn/gravity-compensation> |
+| lerobot-kinematics | <https://github.com/box2ai-robotics/lerobot-kinematics> |
+| Inverted robots overview | <https://www.robots.com/blogs/topsy-turvy-invert-mounted-robots> |
+| Yamaha YK-XGS ceiling SCARA | <https://global.yamaha-motor.com/business/robot/lineup/ykxg/hang_inverse/> |
+| Yaskawa HC inverted arm | <https://knowledge.motoman.com/hc/en-us/articles/23505485971991-HC-Robots-Wall-Mounted-or-Inverted-Arm-Control> |
+| OpenBuilds V-Slot gantry carts | <https://us.openbuilds.com/gantry-carts-kits/> |
+| OpenBuilds Python serial thread | <https://builds.openbuilds.com/threads/python-serial-communication-with-blackbox.18451/> |
+| FluidNC (ESP32 Grbl) | <https://github.com/bdring/FluidNC> |
+| FluidNC WebSocket docs | <http://wiki.fluidnc.com/en/support/interface/websockets> |
+| FluidNC Web API | <http://wiki.fluidnc.com/en/features/WebAPI> |
+| grbl-streamer (PyPI) | <https://pypi.org/project/grbl-streamer/> |
+| ODrive Python (PyPI) | <https://pypi.org/project/odrive/> |
+| Moteus Python (PyPI) | <https://pypi.org/project/moteus/> |
+| TMC2209-PY (PyPI) | <https://pypi.org/project/TMC2209-PY/> |
+| Klipper manual_stepper config | <https://www.klipper3d.org/Config_Reference.html> |
+| moonraker-api (PyPI) | <https://pypi.org/project/moonraker-api/> |
+| igus drylin actuators | <https://www.igus.com/drylin-e/turnkey-linear-actuators> |
+| igus Robot Control (iRC) | <https://www.igus.co.uk/info/robot-software> |
+| ROS ceiling mounting discussion | <https://answers.ros.org/question/321902/mounting-robot-arm-from-ceiling/> |

--- a/docs/outlook-integrations.md
+++ b/docs/outlook-integrations.md
@@ -1,0 +1,233 @@
+---
+title: "Outlook: ELN, LIMS & Protocol Tool Integration"
+purpose: Feasibility study for integrating eLabFTW, SiLA 2, PyLabRobot, and other tools into the workflow
+authority: Research (INFORMATIONAL — not requirements)
+created: 2026-04-12
+updated: 2026-04-12
+---
+
+# Outlook: ELN, LIMS & Protocol Tool Integration
+
+## Concept
+
+The project handles the physical automation layer (arms, pipette, tool changer,
+Bento, gantry, camera). The missing layers are experiment recording, reagent
+inventory, protocol standardization, and device interoperability. This document
+surveys tools that fill those gaps and evaluates their programmability.
+
+## Architecture Vision
+
+```text
++---------------------------------------------+
+|  ELN (eLabFTW / openBIS)                    |  <- experiment records, inventory
++---------------------------------------------+
+|  Protocol Layer (SiLA 2 / Autoprotocol)     |  <- machine-readable protocols
++---------------------------------------------+
+|  Orchestrator (workflow.py)                  |  <- YOU ARE HERE
++---------------------------------------------+
+|  Device Layer (arms, pipette, gantry, etc.) |  <- YOU ARE HERE
++---------------------------------------------+
+|  Dashboard (server.py)                       |  <- YOU ARE HERE
++---------------------------------------------+
+```
+
+## ELN / LIMS Tools
+
+### eLabFTW — Recommended
+
+Open-source (GPLv3), self-hosted via Docker, REST API v2 with full OpenAPI spec.
+
+| Aspect | Detail |
+|--------|--------|
+| Architecture | PHP/MySQL, Docker Compose deployment |
+| API | REST v2, OpenAPI/Swagger, API key auth, no documented rate limits |
+| Python clients | **elAPI** (Uni Heidelberg, v2.4.10, `uv add elapi`) — best DX. **elabapi-python** (official, v5.5.0, auto-generated from OpenAPI) — thin but current |
+| Extensibility | No plugin system, no webhooks. Customization via Docker env vars and API |
+| Docs | Good (docs.elabftw.net, Swagger UI for API exploration) |
+| GitHub | 1,307 stars, 291 forks, actively maintained |
+
+**Integration pattern with this project:**
+
+| Lifecycle | Module | eLabFTW API Call |
+|-----------|--------|-----------------|
+| Pre-run | `workflow.py` pulls protocol | `GET /api/v2/experiments/{template_id}` |
+| Pre-run | `pipette.py` checks reagent stock | `GET /api/v2/items?q=reagent_name` |
+| During | `workflow.py` status events | `PATCH /api/v2/experiments/{id}` (append to body) |
+| Post-run | `camera.py` plate image | `POST /api/v2/experiments/{id}/uploads` |
+| Post-run | Volumes used | `PATCH /api/v2/items/{id}` (decrement stock) |
+| Post-run | Dashboard results | `PATCH /api/v2/experiments/{id}` (status=completed) |
+
+Implementation: an `ELNClient` adapter class wrapping `elapi`, called by the
+workflow orchestrator at lifecycle hooks. Auth via API key in environment
+variable (not YAML — secrets do not belong in config files).
+
+### openBIS / pyBIS — Evaluate
+
+| Aspect | Detail |
+|--------|--------|
+| Package | `pybis` v1.37.4, Python 3.6+, pip-installable |
+| Capabilities | Full CRUD on experiments, samples, datasets, projects. Vocabulary/property management. File upload/download |
+| Jupyter | First-class — designed for notebook workflows |
+| Backed by | ETH Zurich, actively maintained |
+| Docs | Adequate but academic-style |
+| Best for | FAIR data management, Jupyter-driven experiment design |
+
+### Benchling — Skip (Paywalled)
+
+| Aspect | Detail |
+|--------|--------|
+| SDK | `benchling-sdk` v1.24.1, typed, fluent API |
+| Access | **Enterprise plan required** for API access — not free for academics |
+| Webhooks | Supported on Enterprise |
+| Docs | Excellent (best in class) |
+| Verdict | Best SDK quality, but paywalled. Not viable for open-source projects |
+
+### SENAITE LIMS — Skip (Too Heavy)
+
+| Aspect | Detail |
+|--------|--------|
+| API | `senaite.jsonapi` v2.6.0, RESTful JSON, CRU operations |
+| Framework | Plone/Zope stack — heavy, steep learning curve |
+| Docs | Sparse (11 stars, small community) |
+| Verdict | ISO 17025 focus, Plone dependency is a significant adoption barrier |
+
+### SciNote — Skip (Limited)
+
+| Aspect | Detail |
+|--------|--------|
+| API | REST only, no Python SDK |
+| Access | SaaS, free tier exists |
+| Verdict | Basic LIMS, limited automation support |
+
+## Protocol Standardization
+
+### SiLA 2 — Evaluate for Device Interop
+
+Standardization in Lab Automation — gRPC + Protocol Buffers standard for lab
+device communication.
+
+| Aspect | Detail |
+|--------|--------|
+| PyPI | `sila2` v0.14.0 (maintenance-only) — use **UniteLabs fork** instead |
+| Custom servers | Define Feature Definition Language (FDL) XML, generate gRPC stubs, implement handlers. Can wrap any device |
+| Integration | Each hardware module (`DualArmController`, `ElectronicPipette`, `BentoLab`) could expose a SiLA 2 Feature — making them discoverable and interoperable |
+| Real-world OSS | Few public implementations. UniteLabs has examples. Standard is more adopted in pharma (closed-source) |
+| Docs | Adequate for spec, thin for Python library |
+| Used with | Opentrons OT-2, Franka Emika arms (production) |
+
+### Autoprotocol — Skip (Dead)
+
+| Aspect | Detail |
+|--------|--------|
+| Package | `autoprotocol-python` v10.3.0, **last release Apr 2023** |
+| Status | Effectively abandoned (Strateos/Automata acquisition) |
+| Scope | Protocol definition only (JSON AST). Execution required Strateos cloud lab |
+| Verdict | Dead project. Not viable for new integrations |
+
+## Data Pipeline & Analysis Tools
+
+### PyLabRobot — Use (Custom Backend for SO-101)
+
+Hardware-agnostic Python SDK for liquid handling robots.
+
+| Aspect | Detail |
+|--------|--------|
+| Package | `pylabrobot` v0.2.1, 426 stars, 144 forks, MIT |
+| Architecture | `LiquidHandler(backend=XXXBackend(), deck=deck)` — pluggable backends |
+| Custom backends | Implement backend abstract class methods (setup, aspirate, dispense, move). Well-designed for extension |
+| Supported hardware | Hamilton STAR/Vantage, Tecan EVO, Opentrons OT-2, plate readers, centrifuges, pumps, scales |
+| 3D printer backends | **Not supported** — but backend architecture is pluggable enough to write one |
+| Docs | Good (docs.pylabrobot.org, community forum) |
+| Verdict | Write a custom backend for SO-101 arms to make them interoperable with the broader lab automation ecosystem |
+
+### MLflow — Use If Needed
+
+| Aspect | Detail |
+|--------|--------|
+| Package | `mlflow` v3.11.1, 25k+ stars, 60M+ monthly downloads |
+| Wet-lab tracking | `log_param()` / `log_metric()` / `log_artifact()` are domain-agnostic. Track concentrations, temperatures, volumes, OD readings, yields |
+| Verdict | Zero integration cost. Works well as experiment tracker without the ML parts |
+
+### Frictionless Data — Nice to Have
+
+Tabular data packaging with schema validation for CSV experiment results.
+Standardizes output format.
+
+## In-Repo Hardware Status
+
+The project already has hardware integration for Bento Lab and electronic
+pipettes, currently in stub mode pending protocol reverse engineering.
+
+### Bento Lab (bento.bio)
+
+| Aspect | Detail |
+|--------|--------|
+| Interface | BLE (Bluetooth Low Energy) + on-board click-wheel |
+| Protocol | **Closed, undocumented** — no public API, SDK, or serial protocol |
+| Firmware | Proprietary, closed-source. OTA updates via BLE/WiFi |
+| Code in repo | Stub mode (`bento_lab.py`, 121 LOC). Config in `configs/bento_lab.yaml` |
+| Path to control | BLE GATT sniffing (nRF Connect / Wireshark) — sniff app traffic, map GATT characteristics to commands |
+| BOM note | "USB control TBD" |
+
+### Electronic Pipettes (AELAB dPette 7016, DLAB dPette+)
+
+| Aspect | Detail |
+|--------|--------|
+| Interface | USB (calibration-only software, no SDK) |
+| Protocol | **Closed, undocumented** — 2 physical buttons for all operations |
+| Code in repo | Stub mode (`ElectronicPipette` class in `pipette.py`). Config in `configs/pipette.yaml` |
+| 3D scan | `hardware/scans/dpette/` (Revopoint MINI 2, 1:1 mm, PLY/STL) |
+| Control paths (priority) | 1. USB reverse engineering (pyserial + USBREVue/Wireshark). 2. GPIO button bypass (optocoupler). 3. Mechanical button press (servo/second arm) |
+
+### Digital Pipette v2 (DIY Alternative) — Functional
+
+| Aspect | Detail |
+|--------|--------|
+| Interface | Arduino serial (fully documented) |
+| Protocol | Open, published |
+| Code | `digital-pipette-v2` (ac-rad, CC BY 4.0 + MIT) |
+| Status | Functional backend in `pipette.py` |
+
+## Summary: What to Use
+
+| Priority | Tool | Why |
+|----------|------|-----|
+| **Use** | eLabFTW + elAPI | Open-source ELN, Docker-native, mature REST API, `uv`-installable |
+| **Use** | PyLabRobot (custom backend) | Make SO-101 arms interoperable with lab automation ecosystem |
+| **Use if needed** | MLflow | Zero-friction experiment tracking |
+| **Evaluate** | openBIS / pyBIS | FAIR data, Jupyter-native — heavier than eLabFTW |
+| **Evaluate later** | SiLA 2 (UniteLabs) | Device interop standard — overhead for a two-arm setup now |
+| **Skip** | Benchling | Enterprise paywall |
+| **Skip** | Autoprotocol | Dead project |
+| **Skip** | SENAITE | Plone dependency too heavy |
+
+## Quick Refs
+
+| Ref | URL |
+|-----|-----|
+| eLabFTW docs | <https://doc.elabftw.net/> |
+| eLabFTW API v2 spec | <https://doc.elabftw.net/api.html> |
+| elabapi-python (official) | <https://github.com/elabftw/elabapi-python> |
+| elAPI (Uni Heidelberg) | <https://github.com/uhd-urz/elAPI> |
+| NIST eLabFTW Python API | <https://pages.nist.gov/elabftw-python-api/> |
+| openBIS / pyBIS | <https://openbis.ch/> |
+| Benchling SDK docs | <https://docs.benchling.com/> |
+| SENAITE LIMS | <https://www.senaite.com/> |
+| SciNote API | <https://www.scinote.net/product/integrations-and-api/> |
+| SiLA 2 standard | <https://sila-standard.com/standards/> |
+| sila2 (PyPI) | <https://pypi.org/project/sila2/> |
+| SiLA Python (UniteLabs, GitLab) | <https://sila2.gitlab.io/sila_python/> |
+| Autoprotocol | <https://www.autoprotocol.org/> |
+| autoprotocol-python | <https://github.com/autoprotocol/autoprotocol-python> |
+| PyLabRobot (GitHub) | <https://github.com/PyLabRobot/pylabrobot> |
+| PyLabRobot docs | <https://docs.pylabrobot.org/> |
+| PyLabRobot paper (PMC) | <https://pmc.ncbi.nlm.nih.gov/articles/PMC10369895/> |
+| MLflow | <https://mlflow.org/> |
+| Frictionless Data | <https://frictionlessdata.io/> |
+| Bento Bio | <https://www.bento.bio/> |
+| Digital Pipette v2 (ac-rad) | <https://github.com/ac-rad/digital-pipette-v2> |
+| Hackable Syringe Pump | <https://github.com/kjiang8/Hackable-Syringe-Pump> |
+| Poseidon syringe pumps | <https://github.com/pachterlab/poseidon> |
+| GormleyLab Integra pipette | <https://github.com/GormleyLab/Pipette-Liquid-Handler> |
+| Opentrons OT-3 firmware | <https://github.com/Opentrons/ot3-firmware> |
+| USBREVue (USB reverse engineering) | <https://github.com/wcooley/usbrevue> |

--- a/docs/outlook-printer-platforms.md
+++ b/docs/outlook-printer-platforms.md
@@ -1,0 +1,182 @@
+---
+title: "Outlook: 3D Printers & CNC as Pipetting Platforms"
+purpose: Feasibility study for repurposing used 3D printers and CNC machines as Cartesian liquid handlers
+authority: Research (INFORMATIONAL — not requirements)
+created: 2026-04-12
+updated: 2026-04-12
+---
+
+# Outlook: 3D Printers & CNC as Pipetting Platforms
+
+## Concept
+
+Repurpose used/older 3D printers as Cartesian liquid-handling platforms.
+Their existing 3-axis motion systems achieve sufficient accuracy for well-plate
+work at a fraction of the cost of commercial liquid handlers. This complements
+(not replaces) the SO-101 arms — arms handle dexterous tasks (tool changing,
+Bento lid, complex manipulation), while a printer handles high-throughput
+Cartesian pipetting (serial dilutions, plate-to-plate transfers).
+
+## Existing Conversion Projects
+
+### Actively Maintained (Code Public, Python API)
+
+| Project | Base Platform | Python API | PyPI | Stars | License | Docs |
+|---------|--------------|------------|------|-------|---------|------|
+| Science Jubilee | Jubilee (CoreXY, Duet3D) | `Machine` class, Jupyter-native | `science-jubilee` v0.3.2 | 40 | MIT | Good (ReadTheDocs) |
+| PyLabRobot | Hardware-agnostic | Pluggable backends | `pylabrobot` v0.2.1 | 426 | MIT | Good |
+| Opentrons OT-2 | Custom (ex-3D printer) | Protocol API | `opentrons` v9.0.0 | 498 | Apache-2.0 | Excellent |
+| PipetBot-A8 | Anet A8 (Marlin) | `pyotronext` (serial G-code) | No | — | Unknown | Good (dedicated site) |
+
+### Paper-Only (No Public Repo)
+
+| Project | Cost | Key Result | Code |
+|---------|------|------------|------|
+| PALH (Brown, 2024) | ~$400 | Validated qPCR, DNA extraction | No repo |
+| MULA | ~700 EUR | <0.3% pipetting error, Hamilton syringe | Partial (Mendeley, CC BY-NC 3.0) |
+| BioCloneBot | ~$400 | Ender 3 Pro conversion | GitHub (2 stars, C# only, dormant) |
+| FINDUS | <$400 | Fully 3D-printed, <0.3% error | No repo |
+| OTTO | ~$1,500 | OpenBuilds linear rails | No repo |
+| PHIL | — | Miniature, fits on microscope stage | No repo |
+
+## Printer Comparison
+
+| Printer | Build Volume (mm) | Motion | Bed Moves? | Firmware | Used Price | 384-Well? |
+|---------|-------------------|--------|------------|----------|------------|-----------|
+| **Voron 2.4** | 250-350 cubed | **CoreXY** | **No (Z only)** | **Klipper** | $500-800 (kit) | **Yes** |
+| Sovol SV03 | 350x350x400 | Cartesian | Yes (Y) | Marlin | $80-140 | Marginal |
+| Anycubic i3 Mega | 210x210x205 | Cartesian | Yes (Y) | Marlin | $60-120 | No |
+| Geeetech A30 | 320x320x420 | Cartesian | Yes (Y) | Marlin | $80-150 | No |
+| Qidi X-Max | 300x250x300 | Cartesian | Yes (Y) | Marlin fork | $150-250 | Marginal |
+
+**Critical distinction:** Bed-slingers move the bed in Y — moving liquid-filled
+wells risks spillage and positional error. The Voron 2.4 keeps the bed
+stationary in XY, which is essential for plate work.
+
+### Reflashability
+
+All six printers can be reflashed with open firmware. All expose USB serial
+G-code (115200 baud). Qidi X-Max has a locked bootloader on some revisions
+(community workarounds exist).
+
+## Firmware Ecosystems
+
+### Klipper + Moonraker (Voron 2.4)
+
+- Python host (`klippy`) on Raspberry Pi, thin C firmware on MCU.
+- **Custom Python plugins:** `klippy/extras/` directory (~134 modules).
+- **G-code macros:** `[gcode_macro]` with Jinja2 templates and variables.
+  Define `ASPIRATE`, `DISPENSE`, `MOVE_TO_WELL` as macros.
+- **Moonraker API:** REST + WebSocket. `POST /api/printer/command` (G-code),
+  `GET /api/printer/objects/query` (status). Real-time subscriptions.
+- **Python client:** `moonraker-api` on PyPI (v2.0.6) — async WebSocket.
+- **Docs:** Excellent (config reference, API docs at moonraker.readthedocs.io).
+
+### Marlin + OctoPrint (Budget Printers)
+
+- **Serial G-code:** 115200 baud, USB-serial via CH340/FTDI.
+- **Python serial control:** `printrun.printcore` (PyPI, 2.6k stars).
+- **OctoPrint REST API:** `/api/printer/command`, `/api/printer` (status).
+  `octorest` Python client on PyPI.
+- **Custom G-code:** Requires C++ source mod and recompile (not pluggable).
+- **Docs:** Good (OctoPrint API docs excellent, Marlin is config-focused).
+
+### Duet3D / RepRapFirmware (Science Jubilee)
+
+- **HTTP API:** `POST /machine/code` (SBC) or `GET /rr_gcode` (standalone).
+- **Object model:** `GET /machine/status` for full printer state.
+- **Docs:** Good. Simpler than Moonraker for direct G-code but fewer
+  subscription features.
+
+## Conversion Approach
+
+1. **Tool head:** Replace hotend with syringe pump or electronic pipette mount.
+   Extruder stepper (E-axis) drives the plunger. 3D-printed adapters suffice.
+2. **Bed:** Replace with plate holder (3D-printed or machined). Science Jubilee
+   uses a 6-plate deck matching SBS/ANSI footprint (128x86 mm).
+3. **Firmware:** Repurpose E-axis G-code (`G1 E` commands) for aspirate/dispense.
+   Custom macros map volume to stepper steps.
+4. **Calibration:** Home XY to plate corner fiducials; Z-probe to plate surface.
+   Well offset tables from ANSI/SLAS 4-2004 standard.
+
+## Accuracy Requirements
+
+| Plate | Well Pitch | Well Diameter | Required XY Accuracy |
+|-------|-----------|---------------|---------------------|
+| 96-well | 9.0 mm | ~6.5 mm | +/-1.0 mm (comfortable) |
+| 384-well | 4.5 mm | ~3.5 mm | +/-0.5 mm (tight) |
+
+Typical 3D printer repeatability: ~300-500 um (96-well OK, 384-well marginal).
+Voron 2.4 with CoreXY and linear rails: <100 um — meets 384-well comfortably.
+
+## Cost Comparison
+
+| Approach | Cost | Plate Support |
+|----------|------|--------------|
+| Used printer conversion (Ender 3, Sovol) | $325-700 | 96-well |
+| Voron 2.4 build + conversion | $800-1,500 | 96 + 384-well |
+| Science Jubilee (Filastruder kit) | ~$1,500-2,000 | 96 + 384 + tool changing |
+| OpenBuilds custom (OTTO-style) | ~$1,500 | 96 + 384-well |
+| Opentrons OT-2 | $6,000-10,000 | 96 + 384-well |
+| Hamilton STAR/Vantage | $100,000+ | All formats |
+
+## CNC Alternatives
+
+| Platform | Frame | Cost | Rigidity | Suitability |
+|----------|-------|------|----------|-------------|
+| PrintNC | Steel tube | $800-1,200 | Excellent | Overkill — designed for milling forces |
+| MPCNC | Conduit/printed | $300-500 | Low-Medium | Large community, less precise |
+| Workbee | Aluminum extrusion | $600-1,000 | Good | Clean motion, good middle ground |
+
+Trade-off: CNC frames are more rigid but lack ready-made electronics, firmware
+ecosystem, and extruder stepper for pipette actuation.
+
+## Integration with This Project
+
+- **`PipetteConfig` / `ElectronicPipetteConfig`** models already define pipette
+  parameters — same pipette, just mounted on a printer carriage.
+- **`PlateLayout`** model (well positions, pitch, origin offsets) maps directly
+  to G-code well coordinates — the YAML config is already there.
+- **Software layer:** Replace arm IK with G-code generation. PyLabRobot
+  provides a hardware-agnostic Python API that could sit alongside `workflow.py`.
+- **Complementary roles:** Arms handle dexterous tasks. Printer handles
+  high-throughput Cartesian pipetting.
+
+## Voron 2.4 as Standout Candidate
+
+- Stationary bed — no liquid sloshing.
+- CoreXY rigidity — aluminum extrusion + linear rails, <1% dimensional error.
+- Klipper firmware — Python-based, trivial to add custom macros.
+- Quad gantry leveling — automatic bed tramming for consistent Z.
+- No existing Voron lab automation project found — this would be novel.
+
+## Quick Refs
+
+| Ref | URL |
+|-----|-----|
+| Science Jubilee (GitHub) | <https://github.com/machineagency/science-jubilee> |
+| PyLabRobot (GitHub) | <https://github.com/PyLabRobot/pylabrobot> |
+| PyLabRobot docs | <https://docs.pylabrobot.org/> |
+| Opentrons (GitHub) | <https://github.com/Opentrons/opentrons> |
+| Opentrons API docs | <https://docs.opentrons.com/> |
+| PipetBot-A8 | <https://derandere.gitlab.io/pipetbot-a8/> |
+| PALH paper (ScienceDirect) | <https://www.sciencedirect.com/science/article/pii/S2472630324001213> |
+| BioCloneBot (HardwareX) | <https://www.hardware-x.com/article/S2468-0672(24)00010-5/fulltext> |
+| ACS liquid handler paper | <https://pubs.acs.org/doi/10.1021/acs.jchemed.3c00855> |
+| MULA (Printables) | <https://www.printables.com/model/1019242-mula-a-diy-3d-printed-pipetting-robot-enabling-acc> |
+| FINDUS (SLAS) | <https://journals.sagepub.com/doi/10.1177/2472630319877374> |
+| OTTO (Nature Sci. Reports) | <https://www.nature.com/articles/s41598-020-70465-5> |
+| PHIL (Nature Comms) | <https://www.nature.com/articles/s41467-022-30643-7> |
+| Digital Pipette v2 (ac-rad) | <https://github.com/ac-rad/digital-pipette-v2> |
+| Voron Design | <https://vorondesign.com/voron2.4> |
+| Voron 2.4 review (3DPI) | <https://3dprintingindustry.com/news/review-ldo-voron-2-4-300-a-premium-high-speed-diy-3d-printer-236079/> |
+| Sovol refurbished printers | <https://www.sovol3d.com/products/sovol-used-3d-printer> |
+| Anycubic i3 Mega CNC mod | <https://www.printables.com/model/35905-anycubic-i3-mega-cnc-mod> |
+| Klipper config reference | <https://www.klipper3d.org/Config_Reference.html> |
+| Moonraker API docs | <https://moonraker.readthedocs.io/> |
+| moonraker-api (PyPI) | <https://pypi.org/project/moonraker-api/> |
+| printrun (PyPI) | <https://pypi.org/project/printrun/> |
+| OctoPrint REST API | <https://docs.octoprint.org/en/master/api/> |
+| ANSI/SLAS 4-2004 well positions | <https://www.slas.org/SLAS/assets/File/public/standards/ANSI_SLAS_4-2004_WellPositions.pdf> |
+| PrintNC (GitHub) | <https://github.com/threedesigns/printNC> |
+| r/Sovol (Reddit) | <https://www.reddit.com/r/Sovol/> |


### PR DESCRIPTION
## Summary

- **Ceiling-mounted SO-101** — feasibility study for inverted arm on linear rail (mechanical mods, controller programmability, software impact, safety)
- **3D printers & CNC as pipetting platforms** — 9 conversion projects surveyed, printer comparison (Voron 2.4 standout), firmware programmability (Klipper vs Marlin vs Duet3D), accuracy/cost analysis
- **ELN/LIMS/protocol integration** — eLabFTW (recommended), openBIS, SiLA 2, PyLabRobot custom backend, MLflow; includes in-repo hardware status (Bento Lab BLE + dPette USB reverse engineering pending)

All three docs include frontmatter, programmability/API/hackability analysis, and quick refs with URLs.

## Test plan

- [ ] Docs render correctly in GitHub markdown
- [ ] All URLs in quick refs are reachable
- [ ] Frontmatter follows existing docs/ conventions

Generated with Claude <noreply@anthropic.com>