### PR TITLE
chore(Makefile): add PATH hint to setup_node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ setup_slicer: ## Install CuraEngine (preferred) or PrusaSlicer (fallback) for pr
 	fi
 
 setup_node: ## Install Node.js user-locally to ~/.local/share/node (no sudo)
+# After install, add to PATH permanently:
+#   echo 'export PATH="$$HOME/.local/share/node/bin:$$PATH"' >> ~/.bashrc
 	if [ -x "$(NODE_BIN)/node" ]; then
 		echo "node already installed: $$($(NODE_BIN)/node --version) (at $(NODE_DIR))"
 	elif command -v node > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Add comment to `setup_node` target showing how to persist the PATH for tools like Context7 MCP that need `npx`

## Test plan

- [ ] `make setup_node` still works
- [ ] Comment is visible in Makefile

Generated with Claude <noreply@anthropic.com>