### PR TITLE
feat: add eLabFTW, PyLabRobot backend, Cartesian platform (#62, #63, #64)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -61,4 +61,6 @@ exclude = [
     "^https://www\\.hardware-x\\.com",
     # Reddit — 403 to bots
     "^https://www\\.reddit\\.com",
+    # Yaskawa/Motoman — 403 bot protection
+    "^https://knowledge\\.motoman\\.com",
 ]

--- a/app/so101/cartesian_platform.py
+++ b/app/so101/cartesian_platform.py
@@ -1,0 +1,176 @@
+"""Cartesian motion platform via Klipper/Moonraker HTTP API.
+
+A 3-axis (XYZ) Cartesian motion controller for G-code-based pipetting on a
+Voron or similar CoreXY/Cartesian printer running Klipper with Moonraker.
+Communicates over HTTP instead of serial, supporting named positions and
+graceful stub-mode fallback when the printer is unreachable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import yaml
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class CartesianConfig(BaseSettings):
+    """Configuration for the Cartesian motion platform."""
+
+    model_config = SettingsConfigDict(strict=True)
+
+    moonraker_url: str = "http://localhost:7125"
+    timeout_s: float = 10.0
+    safe_z_mm: float = 50.0
+    approach_z_mm: float = 5.0
+    feedrate: int = 3000
+    positions: dict[str, tuple[float, float, float]] = {}
+
+    @field_validator("positions", mode="before")
+    @classmethod
+    def _coerce_positions(cls, v: Any) -> Any:  # noqa: ANN401
+        """Coerce YAML lists to tuples for strict mode."""
+        if isinstance(v, dict):
+            return {k: tuple(val) if isinstance(val, list) else val for k, val in v.items()}
+        return v
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> Self:
+        """Load configuration from a YAML file."""
+        with open(path) as fh:
+            data = yaml.safe_load(fh)
+        return cls.model_validate(data)
+
+
+class CartesianPlatform:
+    """Cartesian motion platform via Klipper/Moonraker HTTP API.
+
+    Usage::
+
+        platform = CartesianPlatform(CartesianConfig(positions={"home": (0, 0, 0)}))
+        platform.connect()
+        platform.home()
+        platform.move_to_position("home")
+        platform.disconnect()
+    """
+
+    def __init__(self, config: CartesianConfig) -> None:
+        """Initialize with platform configuration."""
+        self.config = config
+        self._stub_mode = False
+        self._client: Any = None
+        self._position: tuple[float, float, float] = (0.0, 0.0, 0.0)
+        self._gcode_log: list[str] = []
+
+    def connect(self) -> None:
+        """Connect to Moonraker HTTP API, falling back to stub mode."""
+        try:
+            import httpx as _httpx
+
+            self._client = _httpx.Client(
+                base_url=self.config.moonraker_url,
+                timeout=self.config.timeout_s,
+            )
+            self._client.get("/server/info")
+        except Exception:
+            logger.warning("Moonraker unreachable -- running in stub mode")
+            self._stub_mode = True
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+
+    def disconnect(self) -> None:
+        """Close HTTP client connection."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def send_gcode(self, cmd: str) -> None:
+        """Send a G-code command to the printer.
+
+        In stub mode the command is appended to ``_gcode_log`` instead.
+        """
+        if self._stub_mode:
+            self._gcode_log.append(cmd)
+            return
+        if self._client is not None:
+            self._client.post("/api/printer/command", json={"commands": [cmd]})
+
+    def home(self) -> None:
+        """Home all axes."""
+        self.send_gcode("G28")
+
+    def move_to(self, x: float, y: float, z: float) -> None:
+        """Move to an absolute XYZ position.
+
+        Args:
+            x: X coordinate in mm.
+            y: Y coordinate in mm.
+            z: Z coordinate in mm.
+        """
+        self.send_gcode(self.encode_move(x, y, z, self.config.feedrate))
+        self._position = (x, y, z)
+
+    def move_to_position(self, name: str) -> None:
+        """Move to a named position from configuration.
+
+        Args:
+            name: Position name from ``config.positions``.
+
+        Raises:
+            ValueError: If position name is not configured.
+        """
+        if name not in self.config.positions:
+            raise ValueError(f"Unknown position: {name!r}")
+        x, y, z = self.config.positions[name]
+        self.move_to(x, y, z)
+
+    def raise_to_safe(self) -> None:
+        """Raise Z axis to safe travel height, preserving X and Y."""
+        self.move_to(self._position[0], self._position[1], self.config.safe_z_mm)
+
+    def get_position(self) -> tuple[float, float, float]:
+        """Return current XYZ position.
+
+        In stub mode returns the internally tracked position.
+        When connected, queries the printer for live position.
+        """
+        if self._stub_mode:
+            return self._position
+        if self._client is not None:
+            resp = self._client.post(
+                "/printer/objects/query",
+                json={"objects": {"toolhead": ["position"]}},
+            )
+            pos = resp.json()["result"]["status"]["toolhead"]["position"]
+            return (pos[0], pos[1], pos[2])
+        return self._position
+
+    @property
+    def is_stub_mode(self) -> bool:
+        """Whether the platform is running in stub mode."""
+        return self._stub_mode
+
+    @staticmethod
+    def encode_move(x: float, y: float, z: float, feedrate: int) -> str:
+        """Encode an absolute move as a G0 G-code command.
+
+        Pure function -- no hardware required, safe to call in tests.
+
+        Args:
+            x: X coordinate in mm.
+            y: Y coordinate in mm.
+            z: Z coordinate in mm.
+            feedrate: Travel speed in mm/min.
+
+        Returns:
+            G-code string, e.g. ``"G0 X10.000 Y20.000 Z5.000 F3000"``.
+        """
+        return f"G0 X{x:.3f} Y{y:.3f} Z{z:.3f} F{feedrate}"

--- a/app/so101/cartesian_platform.py
+++ b/app/so101/cartesian_platform.py
@@ -9,7 +9,7 @@ graceful stub-mode fallback when the printer is unreachable.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Self, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -38,7 +38,11 @@ class CartesianConfig(BaseSettings):
     def _coerce_positions(cls, v: Any) -> Any:  # noqa: ANN401
         """Coerce YAML lists to tuples for strict mode."""
         if isinstance(v, dict):
-            return {k: tuple(val) if isinstance(val, list) else val for k, val in v.items()}
+            data = cast("dict[str, Any]", v)
+            return {  # pyright: ignore[reportUnknownVariableType]
+                k: tuple(val) if isinstance(val, list) else val  # pyright: ignore[reportUnknownArgumentType]
+                for k, val in data.items()
+            }
         return v
 
     @classmethod

--- a/app/so101/eln_client.py
+++ b/app/so101/eln_client.py
@@ -1,0 +1,178 @@
+"""eLabFTW Electronic Lab Notebook (ELN) client.
+
+Wraps eLabFTW REST API v2 via the ``elabapi-python`` SDK.  Falls back to
+stub mode when the SDK is not installed or the server is unreachable —
+same graceful-degradation pattern used by :class:`BentoLab`.
+
+Reference: https://www.elabftw.net/
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class ElnConfig(BaseModel):
+    """Configuration for the eLabFTW ELN connection."""
+
+    model_config = ConfigDict(strict=True)
+
+    base_url: str = "https://elab.example.com/api/v2"
+    api_key: str = ""
+    verify_ssl: bool = True
+    timeout_s: float = 30.0
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> Self:
+        """Load configuration from a YAML file."""
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return cls.model_validate(data)
+
+
+class ElnClient:
+    """Client for the eLabFTW Electronic Lab Notebook.
+
+    Usage::
+
+        client = ElnClient(ElnConfig.from_yaml("configs/eln.yaml"))
+        client.connect()
+        exp_id = client.create_experiment("PCR run 2024-01-15")
+        client.update_experiment(exp_id, body="<p>Results …</p>")
+        client.upload_attachment(exp_id, Path("results.csv"))
+        client.disconnect()
+    """
+
+    def __init__(self, config: ElnConfig) -> None:
+        """Initialize with ELN configuration."""
+        self.config = config
+        self._api_client: Any = None
+        self._experiments_api: Any = None
+        self._items_api: Any = None
+        self._uploads_api: Any = None
+        self._stub_mode = False
+
+    def connect(self) -> None:
+        """Connect to the eLabFTW server.
+
+        Tries to import ``elabapi_python`` and configure the API client.
+        Falls back to stub mode on ``ImportError`` or connection failure.
+        """
+        try:
+            import elabapi_python  # type: ignore[import-untyped]
+
+            configuration = elabapi_python.Configuration()
+            configuration.host = self.config.base_url
+            configuration.verify_ssl = self.config.verify_ssl
+            self._api_client = elabapi_python.ApiClient(configuration)
+            self._api_client.set_default_header("Authorization", self.config.api_key)
+            self._experiments_api = elabapi_python.ExperimentsApi(self._api_client)
+            self._items_api = elabapi_python.ItemsApi(self._api_client)
+            self._uploads_api = elabapi_python.UploadsApi(self._api_client)
+            logger.info("eLabFTW connected to %s", self.config.base_url)
+        except ImportError:
+            logger.warning("elabapi-python not installed — running in stub mode")
+            self._stub_mode = True
+        except Exception as exc:
+            logger.warning("eLabFTW connection failed (%s) — running in stub mode", exc)
+            self._stub_mode = True
+
+    @property
+    def is_stub_mode(self) -> bool:
+        """Return whether the client is running in stub mode."""
+        return self._stub_mode
+
+    def create_experiment(self, title: str, body: str = "") -> int:
+        """Create a new experiment.
+
+        Args:
+            title: Experiment title.
+            body: Optional HTML body content.
+
+        Returns:
+            The experiment ID, or ``-1`` in stub mode.
+        """
+        if self._stub_mode or self._experiments_api is None:
+            logger.debug("Stub mode — skipping create_experiment(%r)", title)
+            return -1
+        response = self._experiments_api.post_experiment(
+            body={"title": title, "body": body},
+        )
+        exp_id: int = response.id
+        logger.info("Created experiment %d: %s", exp_id, title)
+        return exp_id
+
+    def update_experiment(
+        self,
+        exp_id: int,
+        body: str | None = None,
+        status: str | None = None,
+    ) -> None:
+        """Update an existing experiment.
+
+        Args:
+            exp_id: Experiment ID to update.
+            body: New HTML body content (optional).
+            status: New status string (optional).
+        """
+        if self._stub_mode or self._experiments_api is None:
+            logger.debug("Stub mode — skipping update_experiment(%d)", exp_id)
+            return
+        patch_body: dict[str, str] = {}
+        if body is not None:
+            patch_body["body"] = body
+        if status is not None:
+            patch_body["status"] = status
+        self._experiments_api.patch_experiment(exp_id, body=patch_body)
+        logger.info("Updated experiment %d", exp_id)
+
+    def upload_attachment(self, exp_id: int, filepath: Path) -> int:
+        """Upload a file attachment to an experiment.
+
+        Args:
+            exp_id: Target experiment ID.
+            filepath: Local file path to upload.
+
+        Returns:
+            The upload ID, or ``-1`` in stub mode.
+        """
+        if self._stub_mode or self._uploads_api is None:
+            logger.debug("Stub mode — skipping upload_attachment(%d)", exp_id)
+            return -1
+        response = self._uploads_api.post_upload("experiments", exp_id, file=str(filepath))
+        upload_id: int = response.id
+        logger.info("Uploaded %s to experiment %d (upload %d)", filepath, exp_id, upload_id)
+        return upload_id
+
+    def get_item(self, item_id: int) -> dict[str, Any]:
+        """Retrieve a database item by ID.
+
+        Args:
+            item_id: The item ID to fetch.
+
+        Returns:
+            Item data as a dictionary, or empty dict in stub mode.
+        """
+        if self._stub_mode or self._items_api is None:
+            logger.debug("Stub mode — skipping get_item(%d)", item_id)
+            return {}
+        response = self._items_api.get_item(item_id)
+        return dict(response.to_dict())
+
+    def disconnect(self) -> None:
+        """Clean up the API client."""
+        if self._api_client is not None:
+            self._api_client = None
+            self._experiments_api = None
+            self._items_api = None
+            self._uploads_api = None
+            logger.info("eLabFTW client disconnected")

--- a/app/so101/eln_client.py
+++ b/app/so101/eln_client.py
@@ -70,14 +70,14 @@ class ElnClient:
         try:
             import elabapi_python  # type: ignore[import-untyped]
 
-            configuration = elabapi_python.Configuration()
-            configuration.host = self.config.base_url
-            configuration.verify_ssl = self.config.verify_ssl
-            self._api_client = elabapi_python.ApiClient(configuration)
-            self._api_client.set_default_header("Authorization", self.config.api_key)
-            self._experiments_api = elabapi_python.ExperimentsApi(self._api_client)
-            self._items_api = elabapi_python.ItemsApi(self._api_client)
-            self._uploads_api = elabapi_python.UploadsApi(self._api_client)
+            configuration = elabapi_python.Configuration()  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
+            configuration.host = self.config.base_url  # pyright: ignore[reportUnknownMemberType]
+            configuration.verify_ssl = self.config.verify_ssl  # pyright: ignore[reportUnknownMemberType]
+            self._api_client = elabapi_python.ApiClient(configuration)  # pyright: ignore[reportUnknownMemberType]
+            self._api_client.set_default_header("Authorization", self.config.api_key)  # pyright: ignore[reportUnknownMemberType]
+            self._experiments_api = elabapi_python.ExperimentsApi(self._api_client)  # pyright: ignore[reportUnknownMemberType]
+            self._items_api = elabapi_python.ItemsApi(self._api_client)  # pyright: ignore[reportUnknownMemberType]
+            self._uploads_api = elabapi_python.UploadsApi(self._api_client)  # pyright: ignore[reportUnknownMemberType]
             logger.info("eLabFTW connected to %s", self.config.base_url)
         except ImportError:
             logger.warning("elabapi-python not installed — running in stub mode")

--- a/app/so101/pylabrobot_backend.py
+++ b/app/so101/pylabrobot_backend.py
@@ -31,14 +31,19 @@ class SO101BackendConfig(BaseModel):
 def _get_base_class() -> type:
     """Return MachineBackend if pylabrobot is installed, else object."""
     try:
-        from pylabrobot.machine import MachineBackend  # pyright: ignore[reportMissingImports]
+        from pylabrobot.machine import (
+            MachineBackend,  # pyright: ignore[reportMissingImports,reportUnknownVariableType]
+        )
 
-        return MachineBackend  # pyright: ignore[reportReturnType]
+        return MachineBackend  # pyright: ignore[reportReturnType,reportUnknownVariableType]
     except ImportError:
         return object
 
 
-class SO101Backend(_get_base_class()):
+_Base: type = _get_base_class()
+
+
+class SO101Backend(_Base):  # pyright: ignore[reportUntypedBaseClass]
     """PyLabRobot backend for SO-101 dual robotic arms.
 
     When pylabrobot is installed, inherits from MachineBackend.

--- a/app/so101/pylabrobot_backend.py
+++ b/app/so101/pylabrobot_backend.py
@@ -1,0 +1,120 @@
+"""PyLabRobot-compatible backend for SO-101 dual robotic arms.
+
+Wraps the existing DualArmController + PipetteProtocol so SO-101 arms
+can be used via the PyLabRobot ecosystem. Falls back to a standalone
+class when pylabrobot is not installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from so101.arms import DualArmController
+    from so101.pipette import PipetteProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class SO101BackendConfig(BaseModel):
+    """Configuration for the SO-101 PyLabRobot backend."""
+
+    model_config = ConfigDict(strict=True)
+
+    arm_id: str = "arm_a"
+    pipette_backend: str = "digital_pipette_v2"
+
+
+def _get_base_class() -> type:
+    """Return MachineBackend if pylabrobot is installed, else object."""
+    try:
+        from pylabrobot.machine import MachineBackend  # pyright: ignore[reportMissingImports]
+
+        return MachineBackend  # pyright: ignore[reportReturnType]
+    except ImportError:
+        return object
+
+
+class SO101Backend(_get_base_class()):
+    """PyLabRobot backend for SO-101 dual robotic arms.
+
+    When pylabrobot is installed, inherits from MachineBackend.
+    Otherwise, provides the same async interface as a standalone class.
+    """
+
+    def __init__(
+        self,
+        config: SO101BackendConfig,
+        arm: DualArmController,
+        pipette: PipetteProtocol,
+    ) -> None:
+        """Initialize with config, arm controller, and pipette.
+
+        Args:
+            config: Backend configuration.
+            arm: Dual arm controller instance.
+            pipette: Pipette backend satisfying PipetteProtocol.
+        """
+        self.config = config
+        self._arm = arm
+        self._pipette = pipette
+        self._stub_mode = False
+
+    async def setup(self) -> None:
+        """Initialize backend (MachineBackend interface)."""
+        if not self._arm.is_connected:
+            self._arm.connect()
+        self._pipette.connect()
+
+    async def stop(self) -> None:
+        """Shutdown backend (MachineBackend interface)."""
+        self._pipette.disconnect()
+
+    async def aspirate(self, volume_ul: float) -> None:
+        """Aspirate via the attached pipette.
+
+        Args:
+            volume_ul: Volume to aspirate in microliters.
+
+        Raises:
+            ValueError: If volume exceeds pipette capacity.
+        """
+        self._pipette.aspirate(volume_ul)
+
+    async def dispense(self, volume_ul: float) -> None:
+        """Dispense via the attached pipette.
+
+        Args:
+            volume_ul: Volume to dispense in microliters.
+
+        Raises:
+            ValueError: If volume exceeds current fill.
+        """
+        self._pipette.dispense(volume_ul)
+
+    async def pick_up_tip(self) -> None:
+        """Placeholder for tip pickup."""
+
+    async def drop_tip(self) -> None:
+        """Eject tip via pipette."""
+        self._pipette.eject_tip()
+
+    async def move_to(self, arm_id: str, position: list[float]) -> None:
+        """Move arm to joint position.
+
+        Args:
+            arm_id: Which arm to control.
+            position: Target joint positions.
+
+        Raises:
+            ValueError: If arm_id is not a configured follower arm.
+        """
+        self._arm.send_action(arm_id, position)
+
+    @property
+    def is_stub_mode(self) -> bool:
+        """Whether the arm controller is running in stub mode."""
+        return self._arm.is_stub_mode

--- a/app/so101/pylabrobot_backend.py
+++ b/app/so101/pylabrobot_backend.py
@@ -31,8 +31,8 @@ class SO101BackendConfig(BaseModel):
 def _get_base_class() -> type:
     """Return MachineBackend if pylabrobot is installed, else object."""
     try:
-        from pylabrobot.machine import (
-            MachineBackend,  # pyright: ignore[reportMissingImports,reportUnknownVariableType]
+        from pylabrobot.machine import (  # pyright: ignore[reportMissingImports]
+            MachineBackend,  # pyright: ignore[reportUnknownVariableType]
         )
 
         return MachineBackend  # pyright: ignore[reportReturnType,reportUnknownVariableType]

--- a/app/so101/workflow.py
+++ b/app/so101/workflow.py
@@ -6,6 +6,8 @@ Use cases (UC):
 - UC3: Tool interchange cycle
 - UC4: Demo mode (all use cases in sequence)
 - UC5: Gantry-based pipetting (XZ gantry + any PipetteProtocol backend)
+- UC6: ELN-logged experiment (wraps any UC with eLabFTW recording)
+- UC7: Cartesian-platform pipetting (Voron/Moonraker + any PipetteProtocol)
 """
 
 from __future__ import annotations
@@ -422,6 +424,72 @@ def uc5_gantry_strip(
     )
     for dest in destinations:
         uc5_gantry_pipette(gantry, pipette, source, dest, volume_ul)
+
+
+def uc6_eln_logged_experiment(
+    eln: Any,  # noqa: ANN401
+    title: str,
+    run_fn: Any,  # noqa: ANN401
+    *args: Any,  # noqa: ANN401
+    **kwargs: Any,  # noqa: ANN401
+) -> int:
+    """UC6: Wrap any use case with eLabFTW experiment recording.
+
+    Creates an experiment before running, updates status on completion or
+    failure, and returns the experiment ID.
+
+    Args:
+        eln: ElnClient instance (or None to skip recording).
+        title: Experiment title.
+        run_fn: Callable to execute (any UC function).
+        *args: Positional arguments forwarded to run_fn.
+        **kwargs: Keyword arguments forwarded to run_fn.
+
+    Returns:
+        Experiment ID, or ``-1`` if eln is None or in stub mode.
+    """
+    exp_id = -1
+    if eln is not None:
+        exp_id = eln.create_experiment(title)
+        logger.info("[UC6] ELN experiment %d: %s", exp_id, title)
+    try:
+        run_fn(*args, **kwargs)
+        if eln is not None:
+            eln.update_experiment(exp_id, status="completed")
+    except Exception:
+        if eln is not None:
+            eln.update_experiment(exp_id, status="failed")
+        raise
+    return exp_id
+
+
+def uc7_cartesian_pipette(
+    platform: Any,  # noqa: ANN401
+    pipette: PipetteProtocol,
+    source: str,
+    dest: str,
+    volume_ul: float,
+) -> None:
+    """UC7: Pipette between named positions using a Cartesian platform.
+
+    Moves via the Cartesian platform (Moonraker/Klipper) instead of a robotic
+    arm.  Same aspirate→dispense cycle as UC5 but on a 3-axis Cartesian system.
+
+    Args:
+        platform: CartesianPlatform instance.
+        pipette: Any PipetteProtocol backend.
+        source: Source position name in platform config.
+        dest: Destination position name in platform config.
+        volume_ul: Volume to transfer in microliters.
+    """
+    logger.info("[UC7] Cartesian: %s → %s (%.1f µL)", source, dest, volume_ul)
+    platform.raise_to_safe()
+    platform.move_to_position(source)
+    pipette.aspirate(volume_ul)
+    platform.raise_to_safe()
+    platform.move_to_position(dest)
+    pipette.dispense(volume_ul)
+    platform.raise_to_safe()
 
 
 def _create_pipette(pipette_config_path: str = "configs/pipette.yaml") -> PipetteProtocol:

--- a/configs/cartesian.yaml
+++ b/configs/cartesian.yaml
@@ -1,0 +1,14 @@
+# Cartesian motion platform configuration (Voron/Moonraker).
+# Uses Klipper/Moonraker HTTP API for G-code-based pipetting.
+
+moonraker_url: "http://localhost:7125"
+timeout_s: 10.0
+safe_z_mm: 50.0
+approach_z_mm: 5.0
+feedrate: 3000
+
+positions:
+  home: [0.0, 0.0, 0.0]
+  plate_a1: [150.0, -50.0, 20.0]
+  plate_h12: [213.0, 13.0, 20.0]
+  reagent_trough: [100.0, -80.0, 30.0]

--- a/configs/eln.yaml
+++ b/configs/eln.yaml
@@ -1,0 +1,7 @@
+# eLabFTW Electronic Lab Notebook configuration.
+# See https://www.elabftw.net/ for server setup.
+
+base_url: "https://elab.example.com/api/v2"
+api_key: ""
+verify_ssl: true
+timeout_s: 30.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ test = [
 cad = [
     "build123d>=0.10",
 ]
+eln = [
+    "elabapi-python>=0.4",
+]
+pylabrobot = [
+    "pylabrobot>=0.2",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["app/so101", "app/dashboard"]

--- a/tests/so101/test_cartesian_platform.py
+++ b/tests/so101/test_cartesian_platform.py
@@ -1,0 +1,170 @@
+"""Tests for Cartesian motion platform (Voron/Moonraker)."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from so101.cartesian_platform import CartesianConfig, CartesianPlatform
+
+
+class TestCartesianConfigModel:
+    """Strict pydantic-settings validation for CartesianConfig."""
+
+    def test_defaults(self) -> None:
+        """Default construction uses field defaults."""
+        cfg = CartesianConfig()
+        assert cfg.moonraker_url == "http://localhost:7125"
+        assert cfg.timeout_s == 10.0
+        assert cfg.safe_z_mm == 50.0
+        assert cfg.feedrate == 3000
+        assert cfg.approach_z_mm == 5.0
+        assert cfg.positions == {}
+
+    def test_strict_rejects_str_for_int(self) -> None:
+        """Feedrate must be int, not str."""
+        with pytest.raises(ValidationError):
+            CartesianConfig(feedrate="3000")  # type: ignore[arg-type]
+
+    def test_strict_rejects_str_for_float(self) -> None:
+        """safe_z_mm must be float, not str."""
+        with pytest.raises(ValidationError):
+            CartesianConfig(safe_z_mm="50")  # type: ignore[arg-type]
+
+    def test_positions_coerce_lists_to_tuples(self) -> None:
+        """YAML loads positions as lists -- before-validator coerces to tuples."""
+        cfg = CartesianConfig.model_validate({"positions": {"home": [0.0, 0.0, 0.0]}})
+        assert cfg.positions["home"] == (0.0, 0.0, 0.0)
+        assert isinstance(cfg.positions["home"], tuple)
+
+    @pytest.mark.integration
+    def test_from_yaml(self) -> None:
+        """Load config from the shipped YAML file."""
+        cfg = CartesianConfig.from_yaml("configs/cartesian.yaml")
+        assert cfg.moonraker_url == "http://localhost:7125"
+        assert "home" in cfg.positions
+        assert isinstance(cfg.positions["home"], tuple)
+        assert len(cfg.positions["home"]) == 3
+
+
+class TestEncodeMove:
+    """Pure function tests for G-code move encoding -- no mocks."""
+
+    def test_encode_basic(self) -> None:
+        """Standard coordinate encoding."""
+        result = CartesianPlatform.encode_move(10, 20, 5, 3000)
+        assert result == "G0 X10.000 Y20.000 Z5.000 F3000"
+
+    def test_encode_negative(self) -> None:
+        """Negative coordinates are valid G-code."""
+        result = CartesianPlatform.encode_move(-10, -20, -5, 1500)
+        assert result == "G0 X-10.000 Y-20.000 Z-5.000 F1500"
+
+    def test_encode_zero(self) -> None:
+        """All-zero coordinates."""
+        result = CartesianPlatform.encode_move(0, 0, 0, 3000)
+        assert result == "G0 X0.000 Y0.000 Z0.000 F3000"
+
+
+@pytest.fixture
+def platform() -> CartesianPlatform:
+    """Return a CartesianPlatform in stub mode (no Moonraker)."""
+    config = CartesianConfig(
+        moonraker_url="http://127.0.0.1:1",  # unreachable
+        positions={
+            "home": (0.0, 0.0, 0.0),
+            "plate_a1": (150.0, -50.0, 20.0),
+            "reagent_trough": (100.0, -80.0, 30.0),
+        },
+    )
+    p = CartesianPlatform(config)
+    p.connect()
+    return p
+
+
+class TestCartesianPlatformStubMode:
+    """Tests for connection fallback to stub mode."""
+
+    def test_connect_unreachable_enters_stub(self) -> None:
+        """Connecting to an unreachable URL enters stub mode."""
+        cfg = CartesianConfig(moonraker_url="http://127.0.0.1:1")
+        p = CartesianPlatform(cfg)
+        p.connect()
+        assert p.is_stub_mode is True
+
+    def test_is_stub_mode_property(self, platform: CartesianPlatform) -> None:
+        """is_stub_mode property reflects stub state."""
+        assert platform.is_stub_mode is True
+
+    def test_disconnect_idempotent(self, platform: CartesianPlatform) -> None:
+        """Calling disconnect multiple times does not raise."""
+        platform.disconnect()
+        platform.disconnect()
+
+
+class TestCartesianPlatformMotion:
+    """Motion tests using stub mode."""
+
+    def test_home_sends_g28(self, platform: CartesianPlatform) -> None:
+        """home() sends G28 via gcode log."""
+        platform.home()
+        assert "G28" in platform._gcode_log
+
+    def test_move_to_updates_position(self, platform: CartesianPlatform) -> None:
+        """move_to updates the tracked position."""
+        platform.move_to(10.0, 20.0, 5.0)
+        assert platform.get_position() == (10.0, 20.0, 5.0)
+
+    def test_move_to_position_named(self, platform: CartesianPlatform) -> None:
+        """move_to_position delegates to move_to with configured coords."""
+        platform.move_to_position("plate_a1")
+        assert platform.get_position() == (150.0, -50.0, 20.0)
+
+    def test_move_to_position_unknown_raises(self, platform: CartesianPlatform) -> None:
+        """Unknown position name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown position"):
+            platform.move_to_position("nonexistent")
+
+    def test_raise_to_safe(self, platform: CartesianPlatform) -> None:
+        """raise_to_safe sets Z to safe_z_mm, preserving X and Y."""
+        platform.move_to(10.0, 20.0, 5.0)
+        platform.raise_to_safe()
+        pos = platform.get_position()
+        assert pos[0] == 10.0
+        assert pos[1] == 20.0
+        assert pos[2] == platform.config.safe_z_mm
+
+    def test_gcode_log_records_commands(self, platform: CartesianPlatform) -> None:
+        """Stub mode logs all G-code commands sent."""
+        platform.home()
+        platform.move_to(1.0, 2.0, 3.0)
+        platform.raise_to_safe()
+        assert len(platform._gcode_log) == 3
+        assert platform._gcode_log[0] == "G28"
+        assert platform._gcode_log[1].startswith("G0 ")
+
+
+class TestCartesianPlatformHypothesis:
+    """Property-based tests for encode_move."""
+
+    @given(
+        x=st.floats(min_value=-500.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+        y=st.floats(min_value=-500.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+        z=st.floats(min_value=-500.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    )
+    def test_encode_move_format(self, x: float, y: float, z: float) -> None:
+        """encode_move always produces a G0 command with X, Y, Z, F fields."""
+        result = CartesianPlatform.encode_move(x, y, z, 3000)
+        assert result.startswith("G0 ")
+        assert " X" in result
+        assert " Y" in result
+        assert " Z" in result
+        assert " F3000" in result
+
+    @given(feedrate=st.integers(min_value=1, max_value=10000))
+    def test_encode_move_feedrate(self, feedrate: int) -> None:
+        """encode_move embeds the feedrate as an integer."""
+        result = CartesianPlatform.encode_move(0, 0, 0, feedrate)
+        assert f"F{feedrate}" in result

--- a/tests/so101/test_eln_client.py
+++ b/tests/so101/test_eln_client.py
@@ -1,0 +1,142 @@
+"""Tests for eLabFTW ELN client."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from so101.eln_client import ElnClient, ElnConfig
+
+
+class TestElnConfigModel:
+    """ElnConfig pydantic model validation."""
+
+    def test_defaults(self) -> None:
+        cfg = ElnConfig()
+        assert cfg.base_url == "https://elab.example.com/api/v2"
+        assert cfg.api_key == ""
+        assert cfg.verify_ssl is True
+        assert cfg.timeout_s == 30.0
+
+    def test_strict_rejects_str_for_float(self) -> None:
+        with pytest.raises(ValidationError):
+            ElnConfig(timeout_s="30")  # type: ignore[arg-type]
+
+    def test_strict_rejects_int_for_str(self) -> None:
+        with pytest.raises(ValidationError):
+            ElnConfig(base_url=123)  # type: ignore[arg-type]
+
+    @pytest.mark.integration
+    def test_from_yaml(self) -> None:
+        cfg = ElnConfig.from_yaml("configs/eln.yaml")
+        assert cfg.base_url == "https://elab.example.com/api/v2"
+        assert cfg.timeout_s == 30.0
+
+
+class TestElnClientStubMode:
+    """Tests for stub mode activation."""
+
+    def test_connect_without_package(self) -> None:
+        """ImportError on elabapi_python triggers stub mode."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "elabapi_python":
+                raise ImportError("no module named elabapi_python")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            client = ElnClient(ElnConfig())
+            client.connect()
+            assert client.is_stub_mode is True
+
+    def test_is_stub_mode_property(self) -> None:
+        client = ElnClient(ElnConfig())
+        assert client.is_stub_mode is False
+        client._stub_mode = True
+        assert client.is_stub_mode is True
+
+    def test_disconnect_idempotent(self) -> None:
+        client = ElnClient(ElnConfig())
+        client.disconnect()
+        client.disconnect()  # second call must not raise
+
+
+class TestElnClientOperations:
+    """Stub-mode operations return safe defaults."""
+
+    @pytest.fixture
+    def stub_client(self) -> ElnClient:
+        """Return an ELN client in stub mode."""
+        client = ElnClient(ElnConfig())
+        client._stub_mode = True
+        return client
+
+    def test_create_experiment_stub(self, stub_client: ElnClient) -> None:
+        assert stub_client.create_experiment("test title") == -1
+
+    def test_update_experiment_stub(self, stub_client: ElnClient) -> None:
+        stub_client.update_experiment(1, body="updated")  # must not raise
+
+    def test_upload_attachment_stub(self, stub_client: ElnClient) -> None:
+        assert stub_client.upload_attachment(1, Path("/tmp/test.csv")) == -1  # noqa: S108
+
+    def test_get_item_stub(self, stub_client: ElnClient) -> None:
+        assert stub_client.get_item(1) == {}
+
+
+class TestElnClientWithMock:
+    """Mock SDK methods to verify API calls."""
+
+    def _make_connected_client(self) -> tuple[ElnClient, MagicMock]:
+        """Create a client with mocked SDK internals."""
+        client = ElnClient(ElnConfig())
+        mock_experiments_api = MagicMock()
+        mock_items_api = MagicMock()
+        mock_uploads_api = MagicMock()
+        client._experiments_api = mock_experiments_api
+        client._items_api = mock_items_api
+        client._uploads_api = mock_uploads_api
+        client._api_client = MagicMock()
+        return client, mock_experiments_api
+
+    def test_create_experiment_calls_api(self) -> None:
+        client, mock_api = self._make_connected_client()
+        mock_api.post_experiment.return_value = MagicMock(id=42)
+        result = client.create_experiment("My Experiment", body="some body")
+        mock_api.post_experiment.assert_called_once()
+        assert result == 42
+
+    def test_update_experiment_calls_api(self) -> None:
+        client, mock_api = self._make_connected_client()
+        client.update_experiment(42, body="new body", status="running")
+        mock_api.patch_experiment.assert_called_once()
+
+    def test_upload_attachment_calls_api(self) -> None:
+        client, _ = self._make_connected_client()
+        mock_uploads = client._uploads_api
+        mock_uploads.post_upload.return_value = MagicMock(id=99)
+        result = client.upload_attachment(42, Path("/tmp/test.csv"))  # noqa: S108
+        mock_uploads.post_upload.assert_called_once()
+        assert result == 99
+
+
+class TestElnConfigHypothesis:
+    """Property-based tests for config construction."""
+
+    @given(st.text())
+    def test_fuzz_base_url(self, url: str) -> None:
+        cfg = ElnConfig(base_url=url)
+        assert cfg.base_url == url
+
+    @given(st.text())
+    def test_fuzz_api_key(self, key: str) -> None:
+        cfg = ElnConfig(api_key=key)
+        assert cfg.api_key == key

--- a/tests/so101/test_pylabrobot_backend.py
+++ b/tests/so101/test_pylabrobot_backend.py
@@ -1,0 +1,157 @@
+"""Tests for PyLabRobot SO-101 backend — strict TDD, async interface."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from so101.arms import ArmConfig, DualArmConfig, DualArmController
+from so101.pipette import DigitalPipette, PipetteConfig
+from so101.pylabrobot_backend import SO101Backend, SO101BackendConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_arm() -> DualArmController:
+    """Create a connected stub-mode dual arm controller."""
+    config = DualArmConfig(
+        arm_a=ArmConfig(arm_id="arm_a", port="/dev/null", role="follower"),
+        arm_b=ArmConfig(arm_id="arm_b", port="/dev/null", role="follower"),
+        positions={"park": [0.0] * 6},
+    )
+    ctrl = DualArmController(config)
+    ctrl.connect()
+    return ctrl
+
+
+@pytest.fixture
+def stub_pipette() -> DigitalPipette:
+    """Create a connected stub-mode digital pipette."""
+    p = DigitalPipette(PipetteConfig(serial_port="/dev/ttyUSB_MISSING", max_volume_ul=200.0))
+    p.connect()
+    return p
+
+
+@pytest.fixture
+def backend(stub_arm: DualArmController, stub_pipette: DigitalPipette) -> SO101Backend:
+    """Create a backend with stub arm and pipette."""
+    config = SO101BackendConfig()
+    return SO101Backend(config, stub_arm, stub_pipette)
+
+
+# ---------------------------------------------------------------------------
+# Config model tests
+# ---------------------------------------------------------------------------
+
+
+class TestSO101BackendConfigModel:
+    """Strict pydantic validation for SO101BackendConfig."""
+
+    def test_defaults(self) -> None:
+        """Default config has arm_id='arm_a' and pipette_backend='digital_pipette_v2'."""
+        cfg = SO101BackendConfig()
+        assert cfg.arm_id == "arm_a"
+        assert cfg.pipette_backend == "digital_pipette_v2"
+
+    def test_strict_rejects_int_for_str(self) -> None:
+        """Strict mode rejects non-string for arm_id."""
+        with pytest.raises(ValidationError):
+            SO101BackendConfig(arm_id=123)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Setup / teardown tests
+# ---------------------------------------------------------------------------
+
+
+class TestSO101BackendSetup:
+    """Backend lifecycle: setup, stop, stub mode."""
+
+    async def test_setup_connects_arm_and_pipette(self, backend: SO101Backend) -> None:
+        """After setup(), the arm is connected."""
+        await backend.setup()
+        assert backend._arm.is_connected
+
+    async def test_stop_disconnects_pipette(self, backend: SO101Backend) -> None:
+        """After stop(), the pipette is disconnected."""
+        await backend.setup()
+        await backend.stop()
+        # Pipette disconnect closes serial; stub mode has _serial=None already,
+        # so we verify stop() completes without error.
+
+    def test_is_stub_mode_delegates_to_arm(self, backend: SO101Backend) -> None:
+        """is_stub_mode reflects the arm controller's stub state."""
+        assert backend.is_stub_mode == backend._arm.is_stub_mode
+
+
+# ---------------------------------------------------------------------------
+# Operation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSO101BackendOperations:
+    """Backend pipette and arm operations delegate correctly."""
+
+    async def test_aspirate_delegates_to_pipette(
+        self, backend: SO101Backend, stub_pipette: DigitalPipette
+    ) -> None:
+        """Aspirate via backend updates pipette fill state."""
+        await backend.aspirate(50.0)
+        # Verify pipette tracked the volume — dispensing 50 should succeed
+        stub_pipette.dispense(50.0)
+
+    async def test_dispense_delegates_to_pipette(
+        self, backend: SO101Backend, stub_pipette: DigitalPipette
+    ) -> None:
+        """Dispense via backend updates pipette fill state."""
+        await backend.aspirate(100.0)
+        await backend.dispense(50.0)
+        # 50 µL remains — dispensing 50 more should succeed
+        stub_pipette.dispense(50.0)
+
+    async def test_aspirate_exceeds_capacity_raises(self, backend: SO101Backend) -> None:
+        """Aspirating beyond max volume raises ValueError."""
+        with pytest.raises(ValueError, match="exceeds max"):
+            await backend.aspirate(300.0)
+
+    async def test_drop_tip_calls_eject(self, backend: SO101Backend) -> None:
+        """drop_tip delegates to pipette eject_tip without error."""
+        await backend.drop_tip()
+
+    async def test_move_to_records_action(
+        self, backend: SO101Backend, stub_arm: DualArmController
+    ) -> None:
+        """move_to sends action to arm, observable via get_observation."""
+        position = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        await backend.move_to("arm_a", position)
+        obs = stub_arm.get_observation("arm_a")
+        assert obs["joints"] == position
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests
+# ---------------------------------------------------------------------------
+
+
+class TestSO101BackendHypothesis:
+    """Property-based tests for backend operations."""
+
+    @given(volume=st.floats(min_value=0.1, max_value=200.0))
+    async def test_aspirate_valid_volume_no_crash(self, volume: float) -> None:
+        """Any valid volume can be aspirated without crashing."""
+        config = DualArmConfig(
+            arm_a=ArmConfig(arm_id="arm_a", port="/dev/null", role="follower"),
+            arm_b=ArmConfig(arm_id="arm_b", port="/dev/null", role="follower"),
+            positions={"park": [0.0] * 6},
+        )
+        ctrl = DualArmController(config)
+        ctrl.connect()
+        p = DigitalPipette(PipetteConfig(serial_port="/dev/ttyUSB_MISSING", max_volume_ul=200.0))
+        p.connect()
+        be = SO101Backend(SO101BackendConfig(), ctrl, p)
+        await be.aspirate(volume)


### PR DESCRIPTION
## Summary

Three new modules implemented via strict TDD in parallel worktrees:

- **#62 eLabFTW ELN client** — `ElnConfig` (strict pydantic) + `ElnClient` wrapping `elabapi-python` SDK with stub-mode fallback. 16 tests.
- **#63 PyLabRobot SO-101 backend** — `SO101BackendConfig` + `SO101Backend` inheriting from `MachineBackend` when available, wrapping `DualArmController` + `PipetteProtocol`. 11 tests.
- **#64 Cartesian pipetting platform** — `CartesianConfig` (strict BaseSettings) + `CartesianPlatform` communicating with Klipper/Moonraker via httpx, following `XZGantry` pattern. 19 tests.

All modules follow existing patterns: strict pydantic configs, stub-mode fallback, behavioral tests, Hypothesis property tests. Optional deps added as dependency groups (`eln`, `pylabrobot`).

**46 new tests, 320 total passing, 0 pyright errors, ruff clean.**

Closes #62, closes #63, closes #64

## Test plan

- [x] 46 new tests pass (`test_eln_client`, `test_pylabrobot_backend`, `test_cartesian_platform`)
- [x] Full suite: 320 passed, 1 deselected
- [x] Pyright strict: 0 errors on all 3 new modules
- [x] Ruff check + format: clean
- [ ] CI checks pass

Generated with Claude <noreply@anthropic.com>