### PR TITLE
docs: SO-101 hardware bringup + mixed-firmware patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ ralph/worktrees/
 /.ripgreprc
 /.claude/agents
 /.claude/commands
+/.claude/worktrees/
 /.idea
 /.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,15 @@ Each document has a specific authority. Do not duplicate information across docu
 | [docs/UserStory.md](docs/UserStory.md) | Acceptance criteria | Both | User stories US-1.1–US-5.2 with testable criteria |
 | [docs/demo-scenarios.md](docs/demo-scenarios.md) | Operations | Both | How to run and verify each use case |
 | [docs/hardware/BOM.md](docs/hardware/BOM.md) | Hardware | Both | Shopping list, vendor links, cost summary |
+| [docs/hardware/bringup.md](docs/hardware/bringup.md) | Hardware — bringup | Both | SO-101 calibration, teleop, firmware patches, troubleshooting |
+| [docs/hardware/two-dof-pipette.md](docs/hardware/two-dof-pipette.md) | Hardware — variant | Both | 2-DOF pipette mode analysis, lerobot integration options |
+| [docs/hardware/cad-tooling.md](docs/hardware/cad-tooling.md) | Hardware — tooling | Both | CAD toolchain (build123d, OpenSCAD, slicer profiles) |
+| [docs/hardware/prusa-mk4-ops.md](docs/hardware/prusa-mk4-ops.md) | Hardware — printer | Both | PrusaLink API, slicer profiles, CAD-to-print pipeline |
+| [app/hardware/README.md](app/hardware/README.md) | Hardware — 3D parts | Both | Printed parts index, assembly instructions, print settings |
 | [docs/research.md](docs/research.md) | Research (informational) | Both | Prior art, papers, community designs, insights |
+| [docs/outlook-printer-platforms.md](docs/outlook-printer-platforms.md) | Vision (informational) | Both | Printer platform comparison (Prusa, Bambu, Creality) |
+| [docs/outlook-integrations.md](docs/outlook-integrations.md) | Vision (informational) | Both | External system integration outlook (ELN, scanner, VLM) |
+| [docs/outlook-ceiling-rail.md](docs/outlook-ceiling-rail.md) | Vision (informational) | Both | Ceiling rail / gantry mounting exploration |
 | [docs/roadmap.md](docs/roadmap.md) | Vision (informational) | Both | Closed-loop printing, tool genesis, VLM/embodied AI phases |
 | [CHANGELOG.md](CHANGELOG.md) | Version history | Both | Keep a Changelog format |
 | [AGENT_LEARNINGS.md](AGENT_LEARNINGS.md) | Patterns | AI agents | Discovered patterns and solutions |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,14 @@ uv run pytest -m "not hardware"
 - Run explicitly: `uv run pytest -m hardware`
 - Require physical arms connected and calibrated
 
+### LeRobot Compatibility Tests (opt-in)
+
+- Tag with `@pytest.mark.lerobot` — excluded from `make test` by default
+- Run explicitly: `uv run --group lerobot pytest -m lerobot`
+- Guards the monkey-patches in `app/so101/patch_lerobot.py` against
+  upstream lerobot drift — runs when lerobot is upgraded or before
+  release, not on every CI pass (lerobot's dep tree is heavy: torch/CUDA)
+
 ### TDD Red-Green-Refactor
 
 - **RED**: Write a failing test that defines the expected behavior

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,23 @@ render_all: render_parts check_prints ## Generate parts + validate printability
 find_port: ## Identify serial port for a single board (unplug USB when prompted)
 	lerobot-find-port
 
+scan_servos: ## Scan a port for STS3215 servos (override: PORT=/dev/ttyACM1)
+	uv run so101-scan-servos --port=$(or $(PORT),/dev/ttyACM0)
+
+install_udev: ## Install udev rule for Waveshare boards (makes ttyACM* world-rw)
+	echo 'SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", MODE="0666"' | \
+		sudo tee /etc/udev/rules.d/99-waveshare.rules
+	sudo udevadm control --reload-rules
+	sudo udevadm trigger
+	echo "udev rule installed. Replug the Waveshare board(s)."
+
+bringup: patch_lerobot scan_servos ## Guided first-bringup: patch lerobot + scan servos
+	echo ""
+	echo "Next steps:"
+	echo "  1. If scan shows mixed firmware, patches are already applied."
+	echo "  2. Run 'make calibrate_arms' (or calibrate individually)."
+	echo "  3. Run 'make start_teleop' to verify leader → follower."
+
 calibrate_arms: ## Calibrate all arms (leader + followers)
 	lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_A_PORT) --robot.id=arm_a
 	lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_B_PORT) --robot.id=arm_b

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,9 @@ check_prints: ## Run slicer printability checks on STLs (CuraEngine or PrusaSlic
 
 render_all: render_parts check_prints ## Generate parts + validate printability
 
+find_port: ## Identify serial port for a single board (unplug USB when prompted)
+	lerobot-find-port
+
 calibrate_arms: ## Calibrate all arms (leader + followers)
 	lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_A_PORT) --robot.id=arm_a
 	lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_B_PORT) --robot.id=arm_b

--- a/Makefile
+++ b/Makefile
@@ -349,13 +349,19 @@ validate: lint check_types test_cov check_complexity ## Full gate (lint + types 
 
 
 eval_policy: ## Evaluate trained policy
-	uv run python scripts/run_demo.py --mode=eval --arm-port=$(FOLLOWER_A_PORT)
+	uv run so101-demo --mode=eval --arm-port=$(FOLLOWER_A_PORT)
 
 serve_dashboard: ## Start remote dashboard
 	uv run uvicorn app.dashboard.server:app --host 0.0.0.0 --port 8080 --reload
 
 run_demo: ## Run full demo pipeline
-	uv run python scripts/run_demo.py --mode=full
+	uv run so101-demo --mode=full
+
+patch_lerobot: ## Apply lerobot patches for mixed STS3215 firmware (prototyping only)
+	uv run so101-patch-lerobot
+
+patch_lerobot_revert: ## Revert lerobot patches
+	uv run so101-patch-lerobot --revert
 
 
 # MARK: HELP

--- a/app/so101/coordinate_cmd.py
+++ b/app/so101/coordinate_cmd.py
@@ -1,9 +1,9 @@
 """Send coordinate-based commands to an SO-101 arm.
 
 Usage:
-    python scripts/coordinate_cmd.py --well A1 --action aspirate
-    python scripts/coordinate_cmd.py --well B3 --action dispense
-    python scripts/coordinate_cmd.py --park
+    uv run so101-coord --well A1 --action aspirate
+    uv run so101-coord --well B3 --action dispense
+    uv run so101-coord --park
 """
 
 from __future__ import annotations

--- a/app/so101/patch_lerobot.py
+++ b/app/so101/patch_lerobot.py
@@ -15,8 +15,8 @@ This script patches the installed lerobot package in-place:
 Re-run after `uv sync` reinstalls lerobot.
 
 Usage:
-    python scripts/patch_firmware_check.py          # apply both patches
-    python scripts/patch_firmware_check.py --revert  # restore originals
+    uv run so101-patch-lerobot           # apply both patches
+    uv run so101-patch-lerobot --revert  # restore originals
 """
 
 from __future__ import annotations

--- a/app/so101/run_demo.py
+++ b/app/so101/run_demo.py
@@ -1,13 +1,13 @@
 """End-to-end demo orchestrator for so101-biolab-automation.
 
 Usage:
-    python scripts/run_demo.py                          # full demo (all use cases)
-    python scripts/run_demo.py --use-case uc1_single --well A1 --volume 50
-    python scripts/run_demo.py --use-case uc1_row --row A
-    python scripts/run_demo.py --use-case uc1_col --col 1
-    python scripts/run_demo.py --use-case uc1_full
-    python scripts/run_demo.py --use-case uc2
-    python scripts/run_demo.py --use-case uc3
+    uv run so101-demo                                   # full demo (all use cases)
+    uv run so101-demo --use-case uc1_single --well A1 --volume 50
+    uv run so101-demo --use-case uc1_row --row A
+    uv run so101-demo --use-case uc1_col --col 1
+    uv run so101-demo --use-case uc1_full
+    uv run so101-demo --use-case uc2
+    uv run so101-demo --use-case uc3
 """
 
 from __future__ import annotations

--- a/app/so101/scan_servos.py
+++ b/app/so101/scan_servos.py
@@ -1,0 +1,94 @@
+"""Scan a serial port for STS3215 servos.
+
+Useful pre-calibration sanity check: verifies the Waveshare board is reachable
+and all expected servos (IDs 1-6 for an SO-101 arm) respond. Reports firmware
+versions so mismatches are visible before `lerobot-calibrate` complains.
+
+Usage:
+    uv run so101-scan-servos                         # defaults to /dev/ttyACM0
+    uv run so101-scan-servos --port=/dev/ttyACM1
+    uv run so101-scan-servos --port=/dev/ttyACM0 --id-range=0-20
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+BAUD = 1_000_000
+ADDR_FIRMWARE_MAJOR = 0
+ADDR_FIRMWARE_MINOR = 1
+
+
+def _parse_range(spec: str) -> range:
+    """Parse 'N-M' as inclusive range."""
+    lo, hi = spec.split("-")
+    return range(int(lo), int(hi) + 1)
+
+
+def scan(port_path: str, ids: range) -> list[tuple[int, int, str]]:
+    """Ping each servo ID; return list of (id, model, firmware) for responders."""
+    try:
+        from scservo_sdk import PacketHandler, PortHandler  # type: ignore[import-untyped]
+    except ImportError as err:
+        raise RuntimeError(
+            "scservo_sdk not installed — run 'uv sync --group lerobot'"
+        ) from err
+
+    port = PortHandler(port_path)
+    if not port.openPort():
+        raise OSError(f"Cannot open {port_path}")
+    port.setBaudRate(BAUD)
+    ph = PacketHandler(0)
+
+    found: list[tuple[int, int, str]] = []
+    try:
+        for sid in ids:
+            model, result, _ = ph.ping(port, sid)
+            if result != 0:
+                continue
+            major, _, _ = ph.read1ByteTxRx(port, sid, ADDR_FIRMWARE_MAJOR)
+            minor, _, _ = ph.read1ByteTxRx(port, sid, ADDR_FIRMWARE_MINOR)
+            found.append((sid, model, f"{major}.{minor}"))
+    finally:
+        port.closePort()
+
+    return found
+
+
+def main() -> None:
+    """CLI entry point for servo scan."""
+    parser = argparse.ArgumentParser(description="Scan serial port for STS3215 servos")
+    parser.add_argument(
+        "--port", default="/dev/ttyACM0", help="serial port (default: /dev/ttyACM0)"
+    )
+    parser.add_argument(
+        "--id-range", default="1-20", help="servo ID range to probe (default: 1-20)"
+    )
+    args = parser.parse_args()
+
+    try:
+        found = scan(args.port, _parse_range(args.id_range))
+    except OSError as err:
+        print(f"ERROR: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    if not found:
+        print(f"No servos found on {args.port}. Check power supply and cable.")
+        sys.exit(2)
+
+    print(f"Found {len(found)} servo(s) on {args.port}:")
+    firmwares = {fw for _, _, fw in found}
+    for sid, model, fw in found:
+        print(f"  ID {sid:>3}  model={model}  firmware={fw}")
+
+    if len(firmwares) > 1:
+        print(
+            f"\nWARNING: mixed firmware versions {sorted(firmwares)}. "
+            "Run 'make patch_lerobot' before calibration.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -29,7 +29,7 @@ Each use case (UC) groups one or more user stories (US) with acceptance criteria
 - [ ] Pipette fill returns to 0 after dispense
 - [ ] Invalid well name raises clear error
 
-**Command:** `python scripts/run_demo.py --use-case uc1_single --well A1 --volume 50`
+**Command:** `uv run so101-demo --use-case uc1_single --well A1 --volume 50`
 
 ### US-1.2: Row/Column Pipetting
 
@@ -44,8 +44,8 @@ Each use case (UC) groups one or more user stories (US) with acceptance criteria
 
 **Commands:**
 
-- `python scripts/run_demo.py --use-case uc1_row --row A --volume 25`
-- `python scripts/run_demo.py --use-case uc1_col --col 1 --volume 20`
+- `uv run so101-demo --use-case uc1_row --row A --volume 25`
+- `uv run so101-demo --use-case uc1_col --col 1 --volume 20`
 
 ### US-1.3: Full Plate Pipetting
 
@@ -57,7 +57,7 @@ Each use case (UC) groups one or more user stories (US) with acceptance criteria
 - [ ] Pipette never overflows (each well is an independent aspirate→dispense)
 - [ ] Sequence follows row-major order (A1, A2, ..., H12)
 
-**Command:** `python scripts/run_demo.py --use-case uc1_full --volume 20`
+**Command:** `uv run so101-demo --use-case uc1_full --volume 20`
 
 ## Fridge Operations (UC2)
 
@@ -73,7 +73,7 @@ Each use case (UC) groups one or more user stories (US) with acceptance criteria
 - [ ] Gripper grabs item from fridge shelf
 - [ ] Arm moves item to park (safe workspace) position
 
-**Command:** `python scripts/run_demo.py --use-case uc2`
+**Command:** `uv run so101-demo --use-case uc2`
 
 ## Tool Interchange (UC3)
 
@@ -88,7 +88,7 @@ Each use case (UC) groups one or more user stories (US) with acceptance criteria
 - [ ] Supports 3 tools: pipette, gripper, fridge hook
 - [ ] Changing to the already-equipped tool is a no-op
 
-**Command:** `python scripts/run_demo.py --use-case uc3`
+**Command:** `uv run so101-demo --use-case uc3`
 
 ## Remote Oversight (UC4)
 
@@ -132,7 +132,7 @@ Each use case (UC) groups one or more user stories (US) with acceptance criteria
 
 **Commands:**
 
-- `python scripts/run_demo.py --use-case uc5_gantry --volume 50`
+- `uv run so101-demo --use-case uc5_gantry --volume 50`
 
 ## Developer Stories
 

--- a/docs/demo-scenarios.md
+++ b/docs/demo-scenarios.md
@@ -26,7 +26,7 @@ make serve          # (optional) start dashboard on :8080
 Aspirate 50 µL from trough, dispense to well A1.
 
 ```bash
-python scripts/run_demo.py --use-case uc1_single --well A1 --volume 50
+uv run so101-demo --use-case uc1_single --well A1 --volume 50
 ```
 
 Expected output:
@@ -44,7 +44,7 @@ Demo complete.
 Pipette all 12 wells in row A at 25 µL each.
 
 ```bash
-python scripts/run_demo.py --use-case uc1_row --row A --volume 25
+uv run so101-demo --use-case uc1_row --row A --volume 25
 ```
 
 Expected: 12 aspirate/dispense cycles (A1 through A12).
@@ -54,7 +54,7 @@ Expected: 12 aspirate/dispense cycles (A1 through A12).
 Pipette all 8 wells in column 1 at 20 µL each.
 
 ```bash
-python scripts/run_demo.py --use-case uc1_col --col 1 --volume 20
+uv run so101-demo --use-case uc1_col --col 1 --volume 20
 ```
 
 Expected: 8 aspirate/dispense cycles (A1 through H1).
@@ -64,7 +64,7 @@ Expected: 8 aspirate/dispense cycles (A1 through H1).
 Pipette all 96 wells at 20 µL each.
 
 ```bash
-python scripts/run_demo.py --use-case uc1_full --volume 20
+uv run so101-demo --use-case uc1_full --volume 20
 ```
 
 Expected: 96 aspirate/dispense cycles. Each well gets an independent aspirate→dispense so the pipette never overflows its 200 µL capacity.
@@ -74,7 +74,7 @@ Expected: 96 aspirate/dispense cycles. Each well gets an independent aspirate→
 Open fridge with hook tool, swap to gripper, grab item, move to park.
 
 ```bash
-python scripts/run_demo.py --use-case uc2
+uv run so101-demo --use-case uc2
 ```
 
 Expected output:
@@ -97,7 +97,7 @@ Parking arm arm_b
 Cycle through all tools: pipette → gripper → fridge hook → gripper.
 
 ```bash
-python scripts/run_demo.py --use-case uc3
+uv run so101-demo --use-case uc3
 ```
 
 Expected output:
@@ -115,13 +115,13 @@ Expected output:
 Runs UC1.1 + UC1.2 (row A) + UC1.2 (column 1) + UC2 + UC3 in sequence.
 
 ```bash
-python scripts/run_demo.py
+uv run so101-demo
 ```
 
 Or equivalently:
 
 ```bash
-python scripts/run_demo.py --use-case all
+uv run so101-demo --use-case all
 ```
 
 ## Dashboard Demo

--- a/docs/hardware/bringup.md
+++ b/docs/hardware/bringup.md
@@ -1,0 +1,274 @@
+# SO-101 Hardware Bringup Guide
+
+Step-by-step procedure for bringing up the SO-101 dual-arm system.
+Tested on Fedora 43, Python 3.12, lerobot 0.4.4.
+
+> **Variant:** For a simplified 2-axis pipetting setup (shoulder_pan +
+> shoulder_lift only, fixed electronic pipette mount), see
+> [two-dof-pipette.md](two-dof-pipette.md).
+
+## Prerequisites
+
+- SO-101 arms assembled (2 followers + 1 leader), STS3215 servos, Waveshare serial bus servo driver boards
+- USB-C cables connecting each Waveshare board to the PC
+- 5V 4A power supplies connected and powered on
+- `uv sync --group lerobot` completed (installs lerobot[feetech])
+
+## 1. Serial Port Permissions
+
+The Waveshare boards register as `/dev/ttyACM*` devices owned by the `dialout` group.
+
+### Add user to dialout group
+
+```bash
+sudo usermod -aG dialout $USER
+```
+
+Requires **full re-login** to take effect (not just a new terminal).
+`newgrp dialout` only affects the current shell, not subprocesses like `uv run`.
+
+### Per-session alternative (no reboot)
+
+```bash
+sudo chmod 666 /dev/ttyACM0 /dev/ttyACM1 /dev/ttyACM2
+```
+
+Run this for **every connected arm** at the start of each session.
+
+> **Note:** Resets on unplug/replug. For persistence, use a udev rule:
+>
+> ```bash
+> sudo sh -c 'echo "SUBSYSTEM==\"tty\", ATTRS{idVendor}==\"1a86\", MODE=\"0666\"" > /etc/udev/rules.d/99-waveshare.rules'
+> sudo udevadm control --reload-rules && sudo udevadm trigger
+> ```
+
+## 2. USB Enumeration
+
+### Find ports
+
+```bash
+uv run lerobot-find-port
+```
+
+Interactive: lists ports, asks you to **unplug** the USB cable, press Enter, then detects which port disappeared.
+
+### Verify with servo scan
+
+```python
+from scservo_sdk import PortHandler, PacketHandler
+
+port = PortHandler("/dev/ttyACM0")
+port.openPort()
+port.setBaudRate(1000000)
+ph = PacketHandler(0)
+
+for sid in range(21):
+    model, result, error = ph.ping(port, sid)
+    if result == 0:
+        print(f"ID {sid}: model={model} err={error}")
+
+port.closePort()
+```
+
+Expected output for one arm: 6 servos (IDs 1-6), model 777 (STS3215).
+
+### Port assignments
+
+| Arm | Default Port | Makefile Variable |
+|-----|-------------|-------------------|
+| Leader | `/dev/ttyACM0` | `LEADER_PORT` |
+| Follower A | `/dev/ttyACM1` | `FOLLOWER_A_PORT` |
+| Follower B | `/dev/ttyACM2` | `FOLLOWER_B_PORT` |
+
+> **Tip:** Port numbers depend on USB plug order, not physical slot. They shift
+> on replug. Always verify with `ls /dev/ttyACM*` and the servo scan. If teleop
+> has the wrong arm moving, swap the ports.
+
+## 3. Firmware Version Check
+
+LeRobot requires all servos on the same firmware version. If versions differ, `lerobot-calibrate` will fail:
+
+```
+RuntimeError: Some Motors use different firmware versions:
+{1: '3.10', 2: '3.9', 3: '3.10', 4: '3.10', 5: '3.10', 6: '3.10'}
+```
+
+### Option A: Flash mismatched servo (proper fix, requires Windows)
+
+Firmware flashing uses a proprietary bootloader protocol — **no Linux tool exists**.
+The `scservo_sdk` / `feetech-servo-sdk` only do register read/write, not firmware upload.
+
+1. Get a Windows machine or VM with USB passthrough
+2. Download FD software + firmware binary from <https://www.feetechrc.com/software>
+3. **Disconnect all other servos** from the daisy chain — firmware flashing
+   cannot address by ID, it uses a power-cycle bootloader handshake
+4. Connect only the mismatched servo to the Waveshare board
+5. Flash via FD tool
+6. Reconnect all servos and verify
+
+### Option B: Patch lerobot (prototyping only)
+
+Mixed firmware causes **two** problems in lerobot 0.4.4:
+
+1. `_assert_same_firmware()` raises `RuntimeError` blocking startup
+2. `sync_read` fails with `[TxRxResult] Incorrect status packet!` — firmware
+   3.9 returns a slightly different packet format that corrupts batch responses
+
+Individual servo reads (`read2ByteTxRx`) work fine for all servos including 3.9.
+The issue is only with sync (batch) reads across the shared bus.
+
+The patch script fixes both:
+
+```bash
+uv run python scripts/patch_firmware_check.py          # apply
+uv run python scripts/patch_firmware_check.py --revert  # restore
+```
+
+What it does:
+
+- **Firmware check:** warns instead of raising `RuntimeError`
+- **sync_read:** falls back to sequential individual reads when batch read fails
+  (firmware 3.9 returns a different packet format that corrupts batch responses;
+  individual reads work fine for all servos including 3.9)
+- **Calibration clamp:** clamps range values to 0-4095 before writing to servo
+  EPROM (glitchy reads via sign-magnitude decoding can produce negatives like -170,
+  which the servo rejects)
+
+This patches the **installed** lerobot package in-place (under `.venv/`).
+The patch is overwritten by `uv sync` — re-run the script after reinstalling.
+
+> **Warning:** Sequential reads are slower than sync reads. This is acceptable
+> for calibration and prototyping but may add latency during teleoperation.
+> For production use, flash all servos to the same firmware version (Option A).
+
+## 4. Pre-calibration Checklist
+
+Before calibrating any arm:
+
+1. **Permissions:** `sudo chmod 666 /dev/ttyACM*` (or udev rule)
+2. **Patches:** `uv run python scripts/patch_firmware_check.py` (if mixed firmware)
+3. **Power:** 5V 4A supply connected and on for each Waveshare board
+4. **Verify servos:** Run the servo scan script (section 2) to confirm 6 servos respond
+
+## 5. Calibrate Leader Arm
+
+```bash
+uv run lerobot-calibrate \
+  --teleop.type=so101_leader \
+  --teleop.port=/dev/ttyACM0 \
+  --teleop.id=leader
+```
+
+> **Important:** Leader arms use `--teleop.*` flags, not `--robot.*`.
+
+### Calibration prompts
+
+The calibration will ask you to move joints to the **middle of their range of motion**.
+Use this as a reference for the neutral pose:
+
+| Joint | Description | Middle position |
+|-------|-------------|-----------------|
+| 1 | Base rotation | Arm pointing straight forward |
+| 2 | Shoulder | ~45°, halfway between up and horizontal |
+| 3 | Elbow | ~90°, forearm halfway bent |
+| 4 | Wrist pitch | Level / neutral |
+| 5 | Wrist roll | Centered, no rotation |
+| 6 | Gripper | Half open |
+
+Put the arm in a relaxed, neutral pose — not at any extreme — then press Enter.
+
+After the midpoint, you'll be asked to move each joint through its full range
+(min to max). Move slowly and smoothly.
+
+Calibration data is saved to `~/.cache/huggingface/lerobot/calibration/leader/`.
+
+## 6. Calibrate Follower Arms
+
+```bash
+# Follower A
+uv run lerobot-calibrate \
+  --robot.type=so101_follower \
+  --robot.port=/dev/ttyACM1 \
+  --robot.id=arm_a
+
+# Follower B
+uv run lerobot-calibrate \
+  --robot.type=so101_follower \
+  --robot.port=/dev/ttyACM2 \
+  --robot.id=arm_b
+```
+
+Or use the Makefile target (calibrates all three sequentially):
+
+```bash
+make calibrate_arms
+```
+
+## 7. Teleoperation Test (Grippers)
+
+After calibration, test leader-follower teleoperation.
+
+### Identify ports with multiple arms
+
+`lerobot-find-port` fails with multiple boards plugged in:
+
+```
+OSError: Could not detect the port. More than one port was found (['/dev/ttyACM1', '/dev/ttyACM0'])
+```
+
+Use `ls /dev/ttyACM*` instead. Port assignment depends on plug order, not
+physical slot. If unsure which is leader vs follower, try one — if the arms
+are swapped, flip the ports.
+
+### Run teleoperation
+
+```bash
+sudo chmod 666 /dev/ttyACM0 /dev/ttyACM1
+uv run lerobot-teleoperate \
+  --robot.type=so101_follower \
+  --robot.port=/dev/ttyACM1 \
+  --teleop.type=so101_leader \
+  --teleop.port=/dev/ttyACM0
+```
+
+Or via Makefile:
+
+```bash
+make start_teleop
+```
+
+Verify the follower arm mirrors the leader's movements.
+
+## 8. Pipette Holder Swap
+
+After grippers are working:
+
+1. Print pipette holders (see [app/hardware/README.md](../../app/hardware/README.md) for parts list and print settings)
+2. Mount holders on follower arm(s)
+3. Re-calibrate if gripper-to-holder swap changes joint offsets
+4. Test tool changer cycle: return gripper, pick up holder
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Permission denied: '/dev/ttyACM0'` | User not in `dialout` group | `sudo chmod 666 /dev/ttyACM*` or add to group + re-login |
+| `newgrp dialout` doesn't help | Only affects current shell, not `uv run` subprocesses | Use `chmod 666` or udev rule instead |
+| `lerobot-find-port` finds nothing | Didn't unplug cable during prompt | Unplug USB, press Enter, replug when told |
+| `lerobot-find-port` multiple ports | Multiple boards plugged in | Use `ls /dev/ttyACM*` instead |
+| `invalid choice: 'so101_leader'` for `--robot.type` | Leader uses `--teleop.type`, not `--robot.type` | Use `--teleop.type=so101_leader` |
+| Firmware version mismatch | Servos on different FW versions | `uv run python scripts/patch_firmware_check.py` or flash with FD |
+| `Incorrect status packet!` on sync_read | FW 3.9 corrupts batch responses | Patch script adds sequential fallback |
+| `Negative values are not allowed` | Glitchy read → negative via sign-magnitude decode | Patch script adds calibration clamp |
+| `Input voltage error!` | Transient servo error during rapid reads | Patch script suppresses; check power if persistent |
+| `Missing motor IDs` (all 6) | Power supply unplugged/off | Connect 5V 4A supply to Waveshare board |
+| `Missing motor IDs` (some) | Servo overload/error lockout or loose cable | Power-cycle the 5V supply, reseat daisy-chain cables |
+| Motor LED blinking during teleop | Servo error (overload/position) | Power-cycle; may indicate port swap (follower treated as leader) |
+| Leader arm stuck / won't move by hand | Ports swapped — leader has torque on | Swap `--robot.port` and `--teleop.port` |
+| `Mismatch between calibration values` | Patched clamp values differ from JSON | Press Enter to use saved calibration — this is expected |
+| Teleop: `--robot.id` / `--teleop.id` missing | IDs default to None, can't find calibration | Always pass `--robot.id=arm_a --teleop.id=leader` |
+| Same min and max during calibration | Joints not moved, or glitchy reads | Move each joint fully; ensure patch is applied |
+| Port number shifted | USB re-enumeration on replug | `ls /dev/ttyACM*`; `sudo chmod 666` again |
+| Gripper not following during teleop | Narrow calibration range on leader gripper | Re-calibrate with full gripper open/close range |
+| Gripper servo LED blinking | Overload error — commanded to out-of-range position | Power-cycle 5V supply; check if gripper moves freely by hand when off |
+| Servo overload after calibration mismatch | Leader/follower gripper ranges don't align | Re-calibrate both arms' grippers with matching full range |

--- a/docs/hardware/bringup.md
+++ b/docs/hardware/bringup.md
@@ -130,6 +130,19 @@ What it does:
 This patches the **installed** lerobot package in-place (under `.venv/`).
 The patch is overwritten by `uv sync` — re-run the script after reinstalling.
 
+### Verifying patch compatibility after lerobot upgrade
+
+The patches use exact-string replacement against lerobot source. When
+bumping the lerobot version, run the compatibility guard tests to catch
+upstream drift before it silently breaks calibration:
+
+```bash
+uv run --group lerobot pytest -m lerobot
+```
+
+If they fail, update the `ORIGINAL` / `PATCHED` constants in
+`app/so101/patch_lerobot.py` to match the new lerobot source.
+
 > **Warning:** Sequential reads are slower than sync reads. This is acceptable
 > for calibration and prototyping but may add latency during teleoperation.
 > For production use, flash all servos to the same firmware version (Option A).

--- a/docs/hardware/bringup.md
+++ b/docs/hardware/bringup.md
@@ -35,12 +35,13 @@ sudo chmod 666 /dev/ttyACM0 /dev/ttyACM1 /dev/ttyACM2
 
 Run this for **every connected arm** at the start of each session.
 
-> **Note:** Resets on unplug/replug. For persistence, use a udev rule:
+> **Note:** Resets on unplug/replug. For persistence, install a udev rule:
 >
 > ```bash
-> sudo sh -c 'echo "SUBSYSTEM==\"tty\", ATTRS{idVendor}==\"1a86\", MODE=\"0666\"" > /etc/udev/rules.d/99-waveshare.rules'
-> sudo udevadm control --reload-rules && sudo udevadm trigger
+> make install_udev
 > ```
+>
+> (writes `/etc/udev/rules.d/99-waveshare.rules` making Waveshare boards world-rw).
 
 ## 2. USB Enumeration
 
@@ -54,23 +55,13 @@ Interactive: lists ports, asks you to **unplug** the USB cable, press Enter, the
 
 ### Verify with servo scan
 
-```python
-from scservo_sdk import PortHandler, PacketHandler
-
-port = PortHandler("/dev/ttyACM0")
-port.openPort()
-port.setBaudRate(1000000)
-ph = PacketHandler(0)
-
-for sid in range(21):
-    model, result, error = ph.ping(port, sid)
-    if result == 0:
-        print(f"ID {sid}: model={model} err={error}")
-
-port.closePort()
+```bash
+uv run so101-scan-servos --port=/dev/ttyACM0   # or: make scan_servos PORT=/dev/ttyACM0
 ```
 
-Expected output for one arm: 6 servos (IDs 1-6), model 777 (STS3215).
+Expected output for one arm: 6 servos (IDs 1-6), model 777 (STS3215),
+with firmware versions listed. A warning is emitted if firmware versions
+differ — run `make patch_lerobot` in that case.
 
 ### Port assignments
 

--- a/docs/hardware/bringup.md
+++ b/docs/hardware/bringup.md
@@ -120,9 +120,11 @@ The issue is only with sync (batch) reads across the shared bus.
 The patch script fixes both:
 
 ```bash
-uv run python scripts/patch_firmware_check.py          # apply
-uv run python scripts/patch_firmware_check.py --revert  # restore
+uv run so101-patch-lerobot           # apply
+uv run so101-patch-lerobot --revert  # restore
 ```
+
+Or via Makefile: `make patch_lerobot` / `make patch_lerobot_revert`.
 
 What it does:
 
@@ -146,7 +148,7 @@ The patch is overwritten by `uv sync` — re-run the script after reinstalling.
 Before calibrating any arm:
 
 1. **Permissions:** `sudo chmod 666 /dev/ttyACM*` (or udev rule)
-2. **Patches:** `uv run python scripts/patch_firmware_check.py` (if mixed firmware)
+2. **Patches:** `uv run so101-patch-lerobot` (if mixed firmware)
 3. **Power:** 5V 4A supply connected and on for each Waveshare board
 4. **Verify servos:** Run the servo scan script (section 2) to confirm 6 servos respond
 
@@ -257,7 +259,7 @@ After grippers are working:
 | `lerobot-find-port` finds nothing | Didn't unplug cable during prompt | Unplug USB, press Enter, replug when told |
 | `lerobot-find-port` multiple ports | Multiple boards plugged in | Use `ls /dev/ttyACM*` instead |
 | `invalid choice: 'so101_leader'` for `--robot.type` | Leader uses `--teleop.type`, not `--robot.type` | Use `--teleop.type=so101_leader` |
-| Firmware version mismatch | Servos on different FW versions | `uv run python scripts/patch_firmware_check.py` or flash with FD |
+| Firmware version mismatch | Servos on different FW versions | `uv run so101-patch-lerobot` or flash with FD |
 | `Incorrect status packet!` on sync_read | FW 3.9 corrupts batch responses | Patch script adds sequential fallback |
 | `Negative values are not allowed` | Glitchy read → negative via sign-magnitude decode | Patch script adds calibration clamp |
 | `Input voltage error!` | Transient servo error during rapid reads | Patch script suppresses; check power if persistent |

--- a/docs/hardware/bringup.md
+++ b/docs/hardware/bringup.md
@@ -79,7 +79,7 @@ differ — run `make patch_lerobot` in that case.
 
 LeRobot requires all servos on the same firmware version. If versions differ, `lerobot-calibrate` will fail:
 
-```
+```text
 RuntimeError: Some Motors use different firmware versions:
 {1: '3.10', 2: '3.9', 3: '3.10', 4: '3.10', 5: '3.10', 6: '3.10'}
 ```
@@ -218,7 +218,7 @@ After calibration, test leader-follower teleoperation.
 
 `lerobot-find-port` fails with multiple boards plugged in:
 
-```
+```text
 OSError: Could not detect the port. More than one port was found (['/dev/ttyACM1', '/dev/ttyACM0'])
 ```
 

--- a/docs/hardware/bringup.md
+++ b/docs/hardware/bringup.md
@@ -47,7 +47,7 @@ Run this for **every connected arm** at the start of each session.
 ### Find ports
 
 ```bash
-uv run lerobot-find-port
+uv run lerobot-find-port   # or: make find_port
 ```
 
 Interactive: lists ports, asks you to **unplug** the USB cable, press Enter, then detects which port disappeared.

--- a/docs/hardware/prusa-mk4-ops.md
+++ b/docs/hardware/prusa-mk4-ops.md
@@ -109,7 +109,7 @@ curl -s --digest -u "maker:$PRUSA_PW" http://192.168.1.86/api/v1/files/usb
 
 ## CAD-to-Print Pipeline
 
-```
+```text
 build123d (.py) → STL → PrusaSlicer → .gcode → PrusaLink PUT → print
 ```
 

--- a/docs/hardware/two-dof-pipette.md
+++ b/docs/hardware/two-dof-pipette.md
@@ -1,0 +1,92 @@
+---
+title: 2-DOF Pipette Mode (SO-101 Variant)
+purpose: Use SO-101 as a 2-axis positioner with fixed pipette mount — shoulder_pan + shoulder_lift only
+authority: Variant configuration (INFORMATIONAL — references bringup.md and architecture.md)
+created: 2026-04-14
+---
+
+# 2-DOF Pipette Mode
+
+Alternate SO-101 configuration: **use only shoulder_pan + shoulder_lift** (joints
+1 and 2) as a 2-axis positioner. A fixed pipette mount replaces the lower arm
+(elbow, wrist, gripper) for simple pipetting workflows.
+
+For standard 6-DOF bringup, see [bringup.md](bringup.md).
+For roadmap context, see [../roadmap.md](../roadmap.md).
+
+## Rationale
+
+- Pipetting often only needs **reach + height** — elbow/wrist articulation is
+  unnecessary overhead
+- Electronic pipette (USB-controlled) handles aspirate/dispense — no servo needed
+  for plunger
+- Simpler kinematics, smaller workspace, cheaper spares (fewer moving servos)
+
+## Mechanical
+
+- Pipette mount attaches **to the upper arm** (post-shoulder, pre-elbow region)
+- Lower arm (servos 3-6) either:
+  - **Removed entirely** — need mechanical plug/cap at upper arm end
+  - **Left attached, parked** — servos 3-6 hold a fixed pose; simplest, no
+    structural changes
+- Electronic pipette (e.g. AELAB dPette 7016, DLAB dPette+) plugged via USB
+  directly to the host PC — plunger actuation is independent of SO-101 servos
+
+## LeRobot Integration Options
+
+LeRobot's `SOFollower` hardcodes all 6 servos in `__init__` (see
+`.venv/lib/python3.12/site-packages/lerobot/robots/so_follower/so_follower.py:54-61`).
+Three ways to use it with fewer motors:
+
+### Option A — Skip lerobot, use scservo_sdk directly (recommended)
+
+Minimal 2-servo controller in `app/so101/two_dof_arm.py` talking directly to
+`scservo_sdk.PacketHandler`. No patches needed. No 6-DOF infrastructure.
+
+**Pros:** Clean, minimal, no lerobot coupling.
+**Cons:** No free policy training / episode recording / teleop (but for fixed
+pipette mode, leader-follower teleop doesn't make much sense anyway).
+
+### Option B — Patch `SOFollower` to use only 2 motors
+
+Add a 4th patch to `scripts/patch_firmware_check.py` that rewrites the motor
+dict in `SOFollower.__init__` to only `shoulder_pan` and `shoulder_lift`.
+
+**Pros:** Reuse `lerobot-calibrate`, `lerobot-teleoperate`, etc.
+**Cons:** Another installed-package patch to maintain. Calibration files from
+this mode won't match 6-DOF files.
+
+### Option C — Subclass in our project
+
+Create `app/so101/two_dof_follower.py` that inherits `SOFollower` and overrides
+`__init__` with only the 2 motors. Used via our `DualArmController`, not
+lerobot CLI.
+
+**Pros:** No upstream patch; clean separation.
+**Cons:** Loses lerobot CLI compatibility (can't use `lerobot-teleoperate`
+unless we also register a custom robot type with draccus).
+
+## Plunger Actuation
+
+Electronic pipette USB protocols are backend-specific. See `app/so101/pipette.py`
+(skeleton) and the BOM for recommended models (AELAB dPette 7016 single-channel,
+DLAB dPette+ 8-channel).
+
+## Recalibration
+
+If swapping from gripper to pipette mount changes joint 1-2 offsets (e.g. the
+mount shifts center of mass or adds a lever arm that affects homing), rerun
+`lerobot-calibrate` for just those joints (requires Option B or C).
+
+Otherwise, standard 6-DOF calibration is fine — joints 3-6 hold their park pose
+and are never commanded to move.
+
+## Known Constraints
+
+- **Workspace** — limited to a cylindrical sector defined by arm length,
+  shoulder_pan range, and shoulder_lift range (no Z-reach beyond the fixed arm
+  length)
+- **Tip pickup** — pipette must press into tip rack by moving the whole arm
+  (shoulder_lift down); no independent Z-axis
+- **Tip ejection** — electronic pipette's built-in ejector button (manual or
+  USB command) since there's no gripper servo to drive the ejector lever

--- a/docs/hardware/two-dof-pipette.md
+++ b/docs/hardware/two-dof-pipette.md
@@ -49,7 +49,7 @@ pipette mode, leader-follower teleop doesn't make much sense anyway).
 
 ### Option B — Patch `SOFollower` to use only 2 motors
 
-Add a 4th patch to `scripts/patch_firmware_check.py` that rewrites the motor
+Add a 4th patch to `app/so101/patch_lerobot.py` that rewrites the motor
 dict in `SOFollower.__init__` to only `shoulder_pan` and `shoulder_lift`.
 
 **Pros:** Reuse `lerobot-calibrate`, `lerobot-teleoperate`, etc.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,6 +18,11 @@ Toward general-purpose voice/agent-to-print. This repo is the first showcase.
 
 **Agent loop** — goal spec → agent generates CAD → slicer validates → printer API → camera + VLM inspects → agent fixes → reprints autonomously
 
+**Hardware bringup:** See [hardware/bringup.md](hardware/bringup.md) for the
+standard 6-DOF SO-101 calibration + teleoperation procedure, and
+[hardware/two-dof-pipette.md](hardware/two-dof-pipette.md) for the simplified
+2-axis pipetting variant.
+
 **Milestones:**
 
 1. **Done** — build123d + CuraEngine CLI pipeline (`make render_parts`, `make check_prints`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,12 +110,13 @@ reportMissingTypeStubs = "none"  # lerobot, pyserial — installed but untyped
 [tool.pytest.ini_options]
 pythonpath = ["app"]
 testpaths = ["tests"]
-addopts = "--strict-markers -m 'not hardware and not network'"
+addopts = "--strict-markers -m 'not hardware and not network and not lerobot'"
 asyncio_mode = "auto"
 markers = [
     "integration: tests loading real config files",
     "network: tests requiring network access",
     "hardware: tests requiring physical SO-101 arms or cameras",
+    "lerobot: tests requiring lerobot package installed (uv sync --group lerobot)",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ packages = ["app/so101", "app/dashboard"]
 
 [project.scripts]
 so101-patch-lerobot = "so101.patch_lerobot:main"
+so101-scan-servos = "so101.scan_servos:main"
 so101-demo = "so101.run_demo:main"
 so101-coord = "so101.coordinate_cmd:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ pylabrobot = [
 [tool.hatch.build.targets.wheel]
 packages = ["app/so101", "app/dashboard"]
 
+[project.scripts]
+so101-patch-lerobot = "so101.patch_lerobot:main"
+so101-demo = "so101.run_demo:main"
+so101-coord = "so101.coordinate_cmd:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -84,7 +89,7 @@ max-complexity = 10
 "app/hardware/cad/**" = ["S603", "ANN"]   # CAD scripts excluded from pyright; annotations deferred
 "app/hardware/**" = ["S603"]    # subprocess calls run trusted internal scripts
 "app/so101/foxglove_viz.py" = ["ANN401"]  # hardware CLI — untyped deps return Any
-"scripts/patch_firmware_check.py" = ["E501"]  # triple-quoted strings mirror lerobot source verbatim
+"app/so101/patch_lerobot.py" = ["E501"]  # triple-quoted strings mirror lerobot source verbatim
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ max-complexity = 10
 "app/hardware/cad/**" = ["S603", "ANN"]   # CAD scripts excluded from pyright; annotations deferred
 "app/hardware/**" = ["S603"]    # subprocess calls run trusted internal scripts
 "app/so101/foxglove_viz.py" = ["ANN401"]  # hardware CLI — untyped deps return Any
+"scripts/patch_firmware_check.py" = ["E501"]  # triple-quoted strings mirror lerobot source verbatim
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ include = ["app/so101", "app/dashboard"]
 exclude = [
     "app/hardware",           # CAD/render/slicer use dynamic imports without type stubs
     "app/so101/foxglove_viz.py",  # hardware CLI — foxglove/lerobot/scipy/yourdfpy all untyped
+    "app/so101/scan_servos.py",   # hardware CLI — scservo_sdk is untyped
 ]
 reportMissingImports = "error"
 reportMissingTypeStubs = "none"  # lerobot, pyserial — installed but untyped

--- a/scripts/patch_firmware_check.py
+++ b/scripts/patch_firmware_check.py
@@ -191,6 +191,7 @@ def _apply_patch(path: Path, original: str, patched: str, name: str, *, revert: 
 
 
 def main() -> None:
+    """Apply or revert lerobot patches based on CLI flags."""
     revert = "--revert" in sys.argv
     action = "Reverting" if revert else "Applying"
     print(f"{action} lerobot patches for mixed firmware workaround...")

--- a/scripts/patch_firmware_check.py
+++ b/scripts/patch_firmware_check.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Patch lerobot to tolerate mixed STS3215 firmware versions.
+
+STS3215 servos may ship with mixed firmware versions (e.g. 3.9 and 3.10).
+LeRobot 0.4.4 has two problems with this:
+
+1. _assert_same_firmware() raises RuntimeError if versions differ
+2. sync_read fails with "Incorrect status packet!" because firmware 3.9
+   returns a slightly different packet format, corrupting the batch response
+
+This script patches the installed lerobot package in-place:
+- Firmware check: warn instead of raise
+- sync_read: fall back to sequential individual reads on failure
+
+Re-run after `uv sync` reinstalls lerobot.
+
+Usage:
+    python scripts/patch_firmware_check.py          # apply both patches
+    python scripts/patch_firmware_check.py --revert  # restore originals
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SITE_PACKAGES = Path(
+    sys.prefix,
+    "lib",
+    f"python{sys.version_info.major}.{sys.version_info.minor}",
+    "site-packages",
+    "lerobot",
+    "motors",
+)
+
+FEETECH_PY = SITE_PACKAGES / "feetech" / "feetech.py"
+MOTORS_BUS_PY = SITE_PACKAGES / "motors_bus.py"
+
+# --- Patch 1: firmware version check ---
+
+FW_ORIGINAL = '''\
+    def _assert_same_firmware(self) -> None:
+        firmware_versions = self._read_firmware_version(self.ids, raise_on_error=True)
+        if len(set(firmware_versions.values())) != 1:
+            raise RuntimeError(
+                "Some Motors use different firmware versions:"
+                f"\\n{pformat(firmware_versions)}\\n"
+                "Update their firmware first using Feetech's software. "
+                "Visit https://www.feetechrc.com/software."
+            )'''
+
+FW_PATCHED = '''\
+    def _assert_same_firmware(self) -> None:
+        firmware_versions = self._read_firmware_version(self.ids, raise_on_error=True)
+        if len(set(firmware_versions.values())) != 1:
+            import logging
+            logging.getLogger("lerobot.motors.feetech").warning(
+                "Mixed firmware versions detected (PATCHED — continuing anyway):"
+                f"\\n{pformat(firmware_versions)}\\n"
+                "For production use, update firmware via Feetech FD software."
+            )'''
+
+# --- Patch 2: sync_read fallback to sequential reads ---
+
+SYNC_ORIGINAL = '''\
+    def _sync_read(
+        self,
+        addr: int,
+        length: int,
+        motor_ids: list[int],
+        *,
+        num_retry: int = 0,
+        raise_on_error: bool = True,
+        err_msg: str = "",
+    ) -> tuple[dict[int, int], int]:
+        self._setup_sync_reader(motor_ids, addr, length)
+        for n_try in range(1 + num_retry):
+            comm = self.sync_reader.txRxPacket()
+            if self._is_comm_success(comm):
+                break
+            logger.debug(
+                f"Failed to sync read @{addr=} ({length=}) on {motor_ids=} ({n_try=}): "
+                + self.packet_handler.getTxRxResult(comm)
+            )
+
+        if not self._is_comm_success(comm) and raise_on_error:
+            raise ConnectionError(f"{err_msg} {self.packet_handler.getTxRxResult(comm)}")
+
+        values = {id_: self.sync_reader.getData(id_, addr, length) for id_ in motor_ids}
+        return values, comm'''
+
+SYNC_PATCHED = '''\
+    _sync_read_warned = False  # PATCHED: suppress repeated warnings
+
+    def _sync_read(
+        self,
+        addr: int,
+        length: int,
+        motor_ids: list[int],
+        *,
+        num_retry: int = 0,
+        raise_on_error: bool = True,
+        err_msg: str = "",
+    ) -> tuple[dict[int, int], int]:
+        self._setup_sync_reader(motor_ids, addr, length)
+        for n_try in range(1 + num_retry):
+            comm = self.sync_reader.txRxPacket()
+            if self._is_comm_success(comm):
+                break
+            logger.debug(
+                f"Failed to sync read @{addr=} ({length=}) on {motor_ids=} ({n_try=}): "
+                + self.packet_handler.getTxRxResult(comm)
+            )
+
+        if self._is_comm_success(comm):
+            values = {id_: self.sync_reader.getData(id_, addr, length) for id_ in motor_ids}
+            return values, comm
+
+        # PATCHED: fall back to sequential individual reads (mixed firmware workaround)
+        if not self._sync_read_warned:
+            logger.warning(
+                f"sync_read failed on {motor_ids=}, using sequential reads "
+                "(mixed firmware workaround, this message shown once)"
+            )
+            self._sync_read_warned = True
+        values = {}
+        last_comm = comm
+        for motor_id in motor_ids:
+            val, c, error = self._read(
+                addr, length, motor_id, num_retry=num_retry, raise_on_error=False
+            )
+            if self._is_error(error):
+                logger.debug(
+                    f"Transient servo error on {motor_id=}: "
+                    + self.packet_handler.getRxPacketError(error)
+                )
+            # Clamp to valid STS3215 range (0-4095) — glitchy reads can return negatives
+            val = max(0, min(4095, val))
+            values[motor_id] = val
+            last_comm = c
+        return values, last_comm'''
+
+
+# --- Patch 3: clamp calibration range values before writing to servo EPROM ---
+
+CAL_ORIGINAL = '''\
+    def write_calibration(self, calibration_dict: dict[str, MotorCalibration], cache: bool = True) -> None:
+        for motor, calibration in calibration_dict.items():
+            if self.protocol_version == 0:
+                self.write("Homing_Offset", motor, calibration.homing_offset)
+            self.write("Min_Position_Limit", motor, calibration.range_min)
+            self.write("Max_Position_Limit", motor, calibration.range_max)'''
+
+CAL_PATCHED = '''\
+    def write_calibration(self, calibration_dict: dict[str, MotorCalibration], cache: bool = True) -> None:
+        for motor, calibration in calibration_dict.items():
+            if self.protocol_version == 0:
+                self.write("Homing_Offset", motor, calibration.homing_offset)
+            # PATCHED: clamp to valid range — glitchy reads can produce negatives
+            range_min = max(0, min(4095, calibration.range_min))
+            range_max = max(0, min(4095, calibration.range_max))
+            self.write("Min_Position_Limit", motor, range_min)
+            self.write("Max_Position_Limit", motor, range_max)'''
+
+
+def _apply_patch(path: Path, original: str, patched: str, name: str, *, revert: bool) -> bool:
+    """Apply or revert a single patch. Returns True if a change was made."""
+    if not path.exists():
+        print(f"  SKIP {name}: {path} not found")
+        return False
+
+    source = path.read_text()
+
+    if revert:
+        if patched not in source:
+            print(f"  SKIP {name}: patch not applied")
+            return False
+        path.write_text(source.replace(patched, original))
+        print(f"  REVERTED {name}: {path}")
+        return True
+
+    if patched in source:
+        print(f"  SKIP {name}: already patched")
+        return False
+    if original not in source:
+        print(f"  ERROR {name}: expected code not found (lerobot version may differ)")
+        return False
+    path.write_text(source.replace(original, patched))
+    print(f"  PATCHED {name}: {path}")
+    return True
+
+
+def main() -> None:
+    revert = "--revert" in sys.argv
+    action = "Reverting" if revert else "Applying"
+    print(f"{action} lerobot patches for mixed firmware workaround...")
+
+    results = [
+        _apply_patch(FEETECH_PY, FW_ORIGINAL, FW_PATCHED, "firmware_check", revert=revert),
+        _apply_patch(MOTORS_BUS_PY, SYNC_ORIGINAL, SYNC_PATCHED, "sync_read_fallback", revert=revert),
+        _apply_patch(FEETECH_PY, CAL_ORIGINAL, CAL_PATCHED, "calibration_clamp", revert=revert),
+    ]
+
+    if not any(results):
+        print("No changes made.")
+    else:
+        print("Done. Re-run after `uv sync` reinstalls lerobot.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_coordinate_cmd.py
+++ b/tests/integration/test_coordinate_cmd.py
@@ -1,40 +1,54 @@
-"""Tests for coordinate_cmd.py script."""
+"""Tests for coordinate_cmd.py — direct main() invocation for coverage."""
 
 from __future__ import annotations
 
-import subprocess
-import sys
+import logging
+
+import pytest
+
+from so101.coordinate_cmd import main
 
 
 class TestCoordinateCmd:
-    """Test coordinate command script via subprocess."""
+    """Test coordinate command script via direct main() call."""
 
-    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            [sys.executable, "-m", "so101.coordinate_cmd", *args],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-
-    def test_well_command(self) -> None:
+    def test_well_command(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """--well A1 exits 0 and logs coordinates."""
-        result = self._run("--well", "A1")
-        assert result.returncode == 0
-        assert "A1" in result.stderr  # logging goes to stderr
+        monkeypatch.setattr("sys.argv", ["so101-coord", "--well", "A1"])
+        with caplog.at_level(logging.INFO):
+            main()
+        assert "A1" in caplog.text
 
-    def test_park_command(self) -> None:
+    def test_park_command(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """--park exits 0."""
-        result = self._run("--park")
-        assert result.returncode == 0
-        assert "Parking" in result.stderr
+        monkeypatch.setattr("sys.argv", ["so101-coord", "--park"])
+        with caplog.at_level(logging.INFO):
+            main()
+        assert "Parking" in caplog.text
 
-    def test_missing_well_and_park(self) -> None:
+    def test_missing_well_and_park(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """No --well and no --park exits non-zero."""
-        result = self._run()
-        assert result.returncode != 0
+        monkeypatch.setattr("sys.argv", ["so101-coord"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
 
-    def test_invalid_well(self) -> None:
+    def test_invalid_well(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """--well Z99 exits non-zero (invalid well name)."""
-        result = self._run("--well", "Z99")
-        assert result.returncode != 0
+        monkeypatch.setattr("sys.argv", ["so101-coord", "--well", "Z99"])
+        with pytest.raises(ValueError, match="Invalid well name"):
+            main()

--- a/tests/integration/test_coordinate_cmd.py
+++ b/tests/integration/test_coordinate_cmd.py
@@ -11,7 +11,7 @@ class TestCoordinateCmd:
 
     def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            [sys.executable, "scripts/coordinate_cmd.py", *args],
+            [sys.executable, "-m", "so101.coordinate_cmd", *args],
             capture_output=True,
             text=True,
             timeout=10,

--- a/tests/integration/test_patch_lerobot_compat.py
+++ b/tests/integration/test_patch_lerobot_compat.py
@@ -1,0 +1,91 @@
+"""Compatibility guard for the lerobot monkey-patches in app/so101/patch_lerobot.py.
+
+## Why this test exists
+
+`app/so101/patch_lerobot.py` modifies the installed lerobot package via
+exact-string replacement. The `ORIGINAL` / `PATCHED` constants must match
+the lerobot source byte-for-byte. When lerobot is upgraded upstream (even
+a whitespace or rename change), the patch script silently becomes a no-op
+— users then hit the original mixed-firmware bugs with no obvious cause.
+
+This test asserts that each patch's code block is still present in the
+installed lerobot source (either the ORIGINAL form, for a clean venv, or
+the PATCHED form, for a venv where the patches have already been applied).
+If neither form is found, the test fails loudly with a pointer to which
+constant needs updating.
+
+## When this test runs
+
+Marked `@pytest.mark.lerobot` — **excluded from `make test`** by default.
+Only runs when you opt in:
+
+    uv run pytest -m lerobot
+
+Or after `uv sync --group lerobot`, typically as part of a pre-release
+check or when bumping the lerobot pin. This avoids forcing every CI run
+to install the heavy lerobot dependency tree (~400MB with torch, CUDA, etc.).
+
+## Troubleshooting a failure
+
+If this test fails after upgrading lerobot:
+  1. Open the offending file in `.venv/lib/python.../site-packages/lerobot/`
+  2. Compare the current source to the `ORIGINAL` constant in patch_lerobot.py
+  3. Update the `ORIGINAL` (and matching `PATCHED`) strings to the new source
+  4. Re-run `uv run so101-patch-lerobot` to re-apply against the new version
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.lerobot
+
+# Skip the entire module if lerobot isn't installed — the test is meaningless
+# without the files to inspect. `importorskip` produces a clean skip message
+# rather than a confusing ImportError.
+pytest.importorskip("lerobot")
+
+
+class TestPatchLerobotCompat:
+    """Assert that each patch's target code block still exists in lerobot source.
+
+    Each test looks for EITHER the ORIGINAL form (unpatched venv) OR the
+    PATCHED form (venv where `so101-patch-lerobot` has already run).
+    A failure means lerobot upstream changed and the patch script needs
+    updating before it can be applied.
+    """
+
+    def test_firmware_check_block_present(self) -> None:
+        """_assert_same_firmware code block must match the patch script's expectation."""
+        # Import here (not at module top) so import errors manifest as test
+        # failures, not collection errors — keeps the skip-if-missing flow clean.
+        from so101.patch_lerobot import FEETECH_PY, FW_ORIGINAL, FW_PATCHED
+
+        source = FEETECH_PY.read_text()
+        assert FW_ORIGINAL in source or FW_PATCHED in source, (
+            f"Neither ORIGINAL nor PATCHED block for _assert_same_firmware found in "
+            f"{FEETECH_PY} — lerobot upstream has drifted. Update FW_ORIGINAL/FW_PATCHED "
+            "in app/so101/patch_lerobot.py to match the new source."
+        )
+
+    def test_sync_read_block_present(self) -> None:
+        """_sync_read code block must match the patch script's expectation."""
+        from so101.patch_lerobot import MOTORS_BUS_PY, SYNC_ORIGINAL, SYNC_PATCHED
+
+        source = MOTORS_BUS_PY.read_text()
+        assert SYNC_ORIGINAL in source or SYNC_PATCHED in source, (
+            f"Neither ORIGINAL nor PATCHED block for _sync_read found in "
+            f"{MOTORS_BUS_PY} — lerobot upstream has drifted. Update "
+            "SYNC_ORIGINAL/SYNC_PATCHED in app/so101/patch_lerobot.py to match."
+        )
+
+    def test_calibration_write_block_present(self) -> None:
+        """write_calibration code block must match the patch script's expectation."""
+        from so101.patch_lerobot import CAL_ORIGINAL, CAL_PATCHED, FEETECH_PY
+
+        source = FEETECH_PY.read_text()
+        assert CAL_ORIGINAL in source or CAL_PATCHED in source, (
+            f"Neither ORIGINAL nor PATCHED block for write_calibration found in "
+            f"{FEETECH_PY} — lerobot upstream has drifted. Update "
+            "CAL_ORIGINAL/CAL_PATCHED in app/so101/patch_lerobot.py to match."
+        )

--- a/tests/integration/test_run_demo.py
+++ b/tests/integration/test_run_demo.py
@@ -11,7 +11,7 @@ class TestRunDemo:
 
     def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            [sys.executable, "scripts/run_demo.py", *args],
+            [sys.executable, "-m", "so101.run_demo", *args],
             capture_output=True,
             text=True,
             timeout=10,

--- a/tests/integration/test_run_demo.py
+++ b/tests/integration/test_run_demo.py
@@ -1,30 +1,37 @@
-"""Tests for run_demo.py script."""
+"""Tests for run_demo.py — calls main() directly for coverage instrumentation."""
 
 from __future__ import annotations
 
-import subprocess
-import sys
+import logging
+from typing import TYPE_CHECKING
+
+from so101.run_demo import main
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class TestRunDemo:
-    """Test demo orchestrator script via subprocess."""
+    """Test demo orchestrator by invoking main() in-process."""
 
-    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            [sys.executable, "-m", "so101.run_demo", *args],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-
-    def test_demo_full_mode(self) -> None:
+    def test_demo_full_mode(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """--mode full exits 0 in stub mode."""
-        result = self._run("--mode", "full")
-        assert result.returncode == 0
-        assert "Demo complete" in result.stderr
+        monkeypatch.setattr("sys.argv", ["so101-demo", "--mode", "full"])
+        with caplog.at_level(logging.INFO):
+            main()
+        assert "Demo complete" in caplog.text
 
-    def test_demo_eval_mode(self) -> None:
+    def test_demo_eval_mode(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """--mode eval exits 0 in stub mode."""
-        result = self._run("--mode", "eval")
-        assert result.returncode == 0
-        assert "Demo complete" in result.stderr
+        monkeypatch.setattr("sys.argv", ["so101-demo", "--mode", "eval"])
+        with caplog.at_level(logging.INFO):
+            main()
+        assert "Demo complete" in caplog.text

--- a/tests/so101/test_eln_client.py
+++ b/tests/so101/test_eln_client.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
@@ -85,8 +88,8 @@ class TestElnClientOperations:
     def test_update_experiment_stub(self, stub_client: ElnClient) -> None:
         stub_client.update_experiment(1, body="updated")  # must not raise
 
-    def test_upload_attachment_stub(self, stub_client: ElnClient) -> None:
-        assert stub_client.upload_attachment(1, Path("/tmp/test.csv")) == -1  # noqa: S108
+    def test_upload_attachment_stub(self, stub_client: ElnClient, tmp_path: Path) -> None:
+        assert stub_client.upload_attachment(1, tmp_path / "test.csv") == -1
 
     def test_get_item_stub(self, stub_client: ElnClient) -> None:
         assert stub_client.get_item(1) == {}
@@ -119,11 +122,11 @@ class TestElnClientWithMock:
         client.update_experiment(42, body="new body", status="running")
         mock_api.patch_experiment.assert_called_once()
 
-    def test_upload_attachment_calls_api(self) -> None:
+    def test_upload_attachment_calls_api(self, tmp_path: Path) -> None:
         client, _ = self._make_connected_client()
         mock_uploads = client._uploads_api
         mock_uploads.post_upload.return_value = MagicMock(id=99)
-        result = client.upload_attachment(42, Path("/tmp/test.csv"))  # noqa: S108
+        result = client.upload_attachment(42, tmp_path / "test.csv")
         mock_uploads.post_upload.assert_called_once()
         assert result == 99
 


### PR DESCRIPTION
## Summary

Captures the full SO-101 first-bringup experience as reusable documentation and tooling:

- **`scripts/patch_firmware_check.py`** — monkey-patches installed lerobot to tolerate mixed STS3215 firmware (FW 3.9 + 3.10 on the same bus): relaxes the version check, adds sequential read fallback when sync_read fails, and clamps calibration range values before writing to servo EPROM
- **`docs/hardware/bringup.md`** — step-by-step guide: permissions, USB enumeration, firmware check, leader/follower calibration, teleoperation test, pipette holder swap, and a troubleshooting table covering every failure mode hit during real bringup
- **`docs/hardware/two-dof-pipette.md`** — new variant doc for using the SO-101 as a 2-axis positioner (shoulder_pan + shoulder_lift only) with a fixed electronic pipette mount; 3 lerobot integration options analysed
- **`docs/roadmap.md`** — cross-links both bringup docs

## Verified

- Leader arm calibrated, saved to `~/.cache/huggingface/lerobot/calibration/teleoperators/so_leader/leader.json`
- Follower A calibrated, saved to `~/.cache/huggingface/lerobot/calibration/robots/so_follower/arm_a.json`
- Teleoperation running at a steady 60Hz with all joints (including gripper) following

## Test plan

- [ ] Review the three patch sections in `scripts/patch_firmware_check.py` for correctness
- [ ] Spot-check bringup.md against a fresh user experience
- [ ] Decide which of the three lerobot integration options in two-dof-pipette.md to implement

Generated with Claude <noreply@anthropic.com>