### PR TITLE
ci: add bump-my-version workflow for semver releases

### DIFF
--- a/.github/scripts/create_pr.sh
+++ b/.github/scripts/create_pr.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# 1 base ref, 2 target ref, 3 title suffix
+# 4 current version, 5 bumped
+
+pr_title="PR $2 $3"
+pr_body="PR automatically created from \`$1\` to bump from \`$4\` to \`$5\` on \`$2\`. Tag \`v$5\` will be created and has to be deleted manually if PR gets closed without merge."
+
+gh pr create \
+  --base $1 \
+  --head $2 \
+  --title "${pr_title}" \
+  --body "${pr_body}"

--- a/.github/scripts/delete_branch_pr_tag.sh
+++ b/.github/scripts/delete_branch_pr_tag.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# 1 repo, 2 target ref, 3 current version
+
+tag_to_delete="v$3"
+branch_del_api_call="repos/$1/git/refs/heads/$2"
+del_msg="'$2' force deletion attempted."
+close_msg="Closing PR '$2' to rollback after failure"
+
+echo "Tag $tag_to_delete for $del_msg"
+git tag -d "$tag_to_delete"
+echo "PR for $del_msg"
+gh pr close "$2" --comment "$close_msg"
+echo "Branch $del_msg"
+gh api "$branch_del_api_call" -X DELETE && \
+  echo "Branch without error return deleted."

--- a/.github/workflows/bump-my-version.yaml
+++ b/.github/workflows/bump-my-version.yaml
@@ -1,0 +1,85 @@
+---
+name: bump-my-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: '[major|minor|patch]'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - 'major'
+        - 'minor'
+        - 'patch'
+
+env:
+  BRANCH_NEW: "bump-${{ github.run_number }}-${{ github.ref_name }}"
+  SKIP_PR_HINT: "[skip ci bump]"
+  SCRIPT_PATH: ".github/scripts"
+
+jobs:
+  bump_my_version:
+    if: >
+        github.event_name == 'workflow_dispatch' ||
+        ( github.event.pull_request.merged == true &&
+        github.event.pull_request.closed_by != 'github-actions' )
+    runs-on: ubuntu-latest
+    outputs:
+      branch_new: ${{ steps.create_branch.outputs.branch_new }}
+    permissions:
+      actions: read
+      checks: write
+      contents: write
+      pull-requests: write
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set git cfg and create branch
+        id: create_branch
+        run: |
+          git config user.email "bumped@qte77.gha"
+          git config user.name "bump-my-version"
+          git checkout -b "${{ env.BRANCH_NEW }}"
+          echo "branch_new=${{ env.BRANCH_NEW }}" >> $GITHUB_OUTPUT
+
+      - name: Bump version
+        id: bump
+        uses: callowayproject/bump-my-version@0.29.0
+        env:
+          BUMPVERSION_TAG: "true"
+        with:
+          args: ${{ inputs.bump_type }}
+          branch: ${{ env.BRANCH_NEW }}
+
+      - name: Regenerate uv.lock
+        if: steps.bump.outputs.bumped == 'true'
+        uses: astral-sh/setup-uv@v5
+      - if: steps.bump.outputs.bumped == 'true'
+        run: |
+          uv lock
+          git add uv.lock
+          git commit --amend --no-edit
+
+      - name: "Create PR '${{ env.BRANCH_NEW }}'"
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          src="${{ env.SCRIPT_PATH }}/create_pr.sh"
+          chmod +x "$src"
+          $src "${{ github.ref_name }}" "${{ env.BRANCH_NEW }}" "${{ env.SKIP_PR_HINT }}" "${{ steps.bump.outputs.previous-version }}" "${{ steps.bump.outputs.current-version }}"
+
+      - name: Delete branch, PR and tag in case of failure or cancel
+        if: failure() || cancelled()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          src="${{ env.SCRIPT_PATH }}/delete_branch_pr_tag.sh"
+          chmod +x "$src"
+          $src "${{ github.repository }}" "${{ env.BRANCH_NEW }}" "${{ steps.bump.outputs.current-version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versi
 
 ### Added
 
+- **Hardware bringup guide** (`docs/hardware/bringup.md`): step-by-step SO-101 calibration, teleoperation, firmware troubleshooting with 13-row diagnostic table
+- **2-DOF pipette variant** (`docs/hardware/two-dof-pipette.md`): analysis of using SO-101 as 2-axis positioner with fixed electronic pipette mount
+- **Mixed-firmware patch tool** (`app/so101/patch_lerobot.py`): monkey-patches lerobot 0.4.4 to tolerate STS3215 servos with mixed firmware (3.9 + 3.10). Entry point: `so101-patch-lerobot`
+- **Servo scan tool** (`app/so101/scan_servos.py`): pre-calibration sanity check reporting servo IDs and firmware versions. Entry point: `so101-scan-servos`
+- **`[project.scripts]` entry points**: `so101-demo`, `so101-coord`, `so101-scan-servos`, `so101-patch-lerobot` — replaces loose `scripts/` directory
+- **Makefile targets**: `find_port`, `scan_servos`, `install_udev`, `bringup`, `patch_lerobot`, `patch_lerobot_revert`
+- **Opt-in `lerobot` pytest marker** for patch compatibility guard tests (`tests/integration/test_patch_lerobot_compat.py`)
+- **9 orphaned docs** added to CONTRIBUTING.md documentation hierarchy table
+
 - **Prusa MK4 slicer profiles** (4 new `.ini` files under `app/hardware/slicer/profiles/`): `prusa_mk4_pla_02mm` (production PLA/PLA+), `prusa_mk4_pla_prototype` (fast 0.3mm fit-check), `prusa_mk4_pla_prototype_supports` (with auto-supports), `prusa_mk4_tpu_02mm` (TPU 95A)
 - **PrusaLink API operations reference** (`docs/hardware/prusa-mk4-ops.md`): endpoint catalog, digest auth, upload + print-after-upload curl examples, CAD-to-print pipeline
 - **dPette+ 3D scan reference data**: `hardware/scans/dpette/0410_02_mesh.{ply,stl}` (1:1 mm Revopoint scan) + `hardware/scans/dpette/README.md` (provenance, scale, intended use)
@@ -32,6 +41,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versi
 
 ### Changed
 
+- **Scripts moved** from `scripts/` to `app/so101/` as proper package entry points via hatchling
+- **Integration tests refactored** to call `main()` directly (not subprocess) — coverage: 75% → 80%
+- **ELN client** (`app/so101/eln_client.py`): 10 inline pyright ignores replaced with single `Any` cast on untyped `elabapi_python` import
+- **Coverage gate** enforced at 80% in CI (`--cov-fail-under=80`)
 - **Code / assets split**: generated STL + SVG outputs moved from `app/hardware/{stl,svg}/` to top-level `hardware/{stl,svg}/`. Code (CAD scripts, `render.py`, `slicer/`, `parts.json`) stays under `app/hardware/`. New top-level `hardware/scans/` for reference 3D scan data. `render.py`, `slicer/validate.py`, `cad/util/export.py`, `tests/_paths.py` all updated to resolve asset paths via a new `ASSETS_DIR` anchor.
 - `app/hardware/README.md` restructured: removed duplicated Parts Table (→ points at `parts.json` as single source of truth + `jq` query examples) and duplicated layout description (→ points at `docs/architecture.md`). Added dPette+ 8-ch Mount + dPette single-channel Mount + Scan Reference Data assembly sections, Prusa MK4 slicer profile catalog.
 - `parts.json` `notes` fields trimmed to short descriptive labels — provenance prose moved to commit history per DRY.
@@ -50,6 +63,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versi
 
 ### Fixed
 
+- Fenced code blocks missing language specifier (MD040) in bringup.md and prusa-mk4-ops.md
+- Hardcoded `/tmp` paths in test_eln_client.py replaced with `tmp_path` fixture (Bandit B108)
+- `feetechrc.com` excluded from lychee link checker (TLS handshake failure in CI)
 - `app/hardware/cad/util/export.py` (`export_part`): handles `ShapeList` results from build123d boolean operations via a `_to_compound` coercion helper (disconnected shapes no longer fail with `AttributeError: ShapeList has no wrapped`)
 - `tests/so101/test_arms.py`: pre-existing ruff drift — B007 (unused loop var `arm_id` → `_arm_id`) + RUF043 (non-raw regex `"[Ll]eader"` → `r"[Ll]eader"` in `pytest.raises(match=...)`)
 - `arms.py`: stub-safe `get_observation` / `send_action` when LeRobot unavailable

--- a/README.md
+++ b/README.md
@@ -64,14 +64,24 @@ See [docs/architecture.md](docs/architecture.md) for full system design, module 
 
 ## Project Structure
 
-- `app/` — software (arms, pipette, workflow, dashboard, CAD pipeline)
-- `hardware/` — CAD sources, STLs, SVGs for 3D-printed parts
+- `app/so101/` — core library + CLI entry points (arms, pipette, workflow, safety, ELN)
+- `app/dashboard/` — FastAPI remote oversight dashboard
+- `app/hardware/` — CAD pipeline (build123d, slicer, renderer)
+- `hardware/` — generated STLs, SVGs, 3D scan data
 - `configs/` — YAML runtime config (ports, positions, backends)
-- `scripts/` — CLI entry points
-- `docs/` — design, user stories, demo scenarios, BOM, research
-- `tests/` — unit + property tests
+- `docs/` — design, user stories, demo scenarios, BOM, research, hardware bringup
+- `tests/` — unit, integration, property-based tests (80% coverage gate)
 
 See [docs/architecture.md](docs/architecture.md) for module responsibilities and data flows.
+
+## CLI Entry Points
+
+```bash
+uv run so101-demo              # run demo pipetting workflows
+uv run so101-coord             # send coordinate commands to an arm
+uv run so101-scan-servos       # scan serial port for STS3215 servos
+uv run so101-patch-lerobot     # patch lerobot for mixed firmware (prototyping)
+```
 
 ## Documentation
 
@@ -79,6 +89,7 @@ See [docs/architecture.md](docs/architecture.md) for module responsibilities and
 - [User Stories](docs/UserStory.md) — use case (UC1-5) acceptance criteria
 - [Demo Scenarios](docs/demo-scenarios.md) — how to run and verify each use case
 - [Hardware BOM](docs/hardware/BOM.md) — shopping list with links ($350-$3000+)
+- [Hardware Bringup](docs/hardware/bringup.md) — SO-101 calibration, teleop, firmware patches
 - [Research](docs/research.md) — prior art, papers, community designs, insights
 - [Roadmap](docs/roadmap.md) — closed-loop printing, tool genesis, VLM/embodied AI vision
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,5 +120,37 @@ markers = [
     "lerobot: tests requiring lerobot package installed (uv sync --group lerobot)",
 ]
 
+[tool.bumpversion]
+current_version = "0.1.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+commit = true
+tag = true
+allow_dirty = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+message = "Bump version: {current_version} → {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "version-{current_version}--alpha-58f4c2"
+replace = "version-{new_version}-58f4c2"
+
+[[tool.bumpversion.files]]
+filename = "CHANGELOG.md"
+search = """
+## [Unreleased]
+"""
+replace = """
+## [Unreleased]
+
+## [{new_version}] - {now:%Y-%m-%d}
+"""
+
 [tool.coverage.run]
 omit = ["app/so101/foxglove_viz.py"]  # hardware CLI — requires real arms + cameras


### PR DESCRIPTION
## Summary
- Port `bump-my-version` GHA workflow from Agents-eval
- `[tool.bumpversion]` config bumps version in pyproject.toml, README badge, CHANGELOG header
- Post-bump `uv lock` regeneration step (Agents-eval adaptation)
- Helper scripts for PR creation + rollback on failure

## Usage
Actions tab → `bump-my-version` → Run workflow → choose major/minor/patch

## Files bumped
| File | Pattern |
|------|---------|
| `pyproject.toml` | `version = "X.Y.Z"` |
| `README.md` | Shield badge `version-X.Y.Z` |
| `CHANGELOG.md` | `[Unreleased]` → `[Unreleased]\n\n## [X.Y.Z] - YYYY-MM-DD` |
| `uv.lock` | Regenerated by `uv lock` |

## Test plan
- [ ] Trigger workflow_dispatch manually after merge
- [ ] Verify PR is created with correct version bump
- [ ] Verify uv.lock is regenerated in the bump commit

Generated with Claude <noreply@anthropic.com>