### PR TITLE
ci: pin all GHA actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/bump-my-version.yaml
+++ b/.github/workflows/bump-my-version.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           fetch-depth: 1
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Bump version
         id: bump
-        uses: callowayproject/bump-my-version@0.29.0
+        uses: callowayproject/bump-my-version@6a3546ba018192b2b830bc15ea612441adfb9b5b  # v0.29.0
         env:
           BUMPVERSION_TAG: "true"
         with:
@@ -59,7 +59,7 @@ jobs:
 
       - name: Regenerate uv.lock
         if: steps.bump.outputs.bumped == 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - if: steps.bump.outputs.bumped == 'true'
         run: |
           uv lock

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -43,7 +43,7 @@ jobs:
         run: gh api "repos/$REPO/dependency-graph/sbom" --jq '.sbom' > "$SBOM_DIR/github-depgraph.spdx.json"
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610  # v0
 
       - name: Generate Syft SPDX SBOM
         run: syft dir:. -o spdx-json="$SBOM_DIR/syft-scan.spdx.json"

--- a/.github/workflows/write-llms-txt.yaml
+++ b/.github/workflows/write-llms-txt.yaml
@@ -21,7 +21,7 @@ jobs:
       REPO: ${{ github.repository }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
       - name: Validate template links exist
         run: |


### PR DESCRIPTION
## Summary
Pin 6 unpinned action references to full SHAs, enabling the repo setting
"Require actions to be pinned to a full-length commit SHA".

Also aligns bump-my-version.yaml to use checkout v6 + setup-uv v7
(was v4/v5, inconsistent with other workflows).

## Test plan
- [x] `grep 'uses:.*@v[0-9]' .github/workflows/*.yaml` → no matches
- [ ] CI passes on this PR
- [ ] After merge: enable SHA pinning requirement in repo settings

Generated with Claude <noreply@anthropic.com>