### PR TITLE
fix(ci): prevent SBOM workflow self-trigger loop

### DIFF
--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -3,6 +3,8 @@ name: Generate SBOM
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/SBOM/**"
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Add `paths-ignore: docs/SBOM/**` to `generate-sbom.yaml` push trigger
- Breaks the cascade where merging an SBOM PR re-triggers the workflow, producing redundant PRs (e.g. #89–#98)

## Test plan

- [ ] Merge this PR and verify no new auto SBOM PR is created
- [ ] Verify weekly cron and `workflow_dispatch` still work

Generated with Claude <noreply@anthropic.com>