### PR TITLE
fix(docs): update app/hardware → src/hardware link in demo-scenarios

### DIFF
--- a/docs/demo-scenarios.md
+++ b/docs/demo-scenarios.md
@@ -17,7 +17,7 @@ make setup_all      # install all dependencies + tools
 make serve          # (optional) start dashboard on :8080
 ```
 
-**Physical demo setup (optional).** The pipetting use cases (UC1, UC5) can be demonstrated on real hardware once the printed parts and pipette are mounted. The DLAB dPette+ 8-channel mount is the primary configuration — see [../app/hardware/README.md](../app/hardware/README.md#dpette-8-channel-mount-replaces-so-101-gripper-jaws) for the assembly and print settings, [../docs/hardware/BOM.md](hardware/BOM.md) for the parts list, and [prusa-mk4-ops.md](hardware/prusa-mk4-ops.md) for uploading gcode to a Prusa MK4 via PrusaLink. All demo commands below also run cleanly in **stub mode** without any hardware.
+**Physical demo setup (optional).** The pipetting use cases (UC1, UC5) can be demonstrated on real hardware once the printed parts and pipette are mounted. The DLAB dPette+ 8-channel mount is the primary configuration — see [../src/hardware/README.md](../src/hardware/README.md#dpette-8-channel-mount-replaces-so-101-gripper-jaws) for the assembly and print settings, [../docs/hardware/BOM.md](hardware/BOM.md) for the parts list, and [prusa-mk4-ops.md](hardware/prusa-mk4-ops.md) for uploading gcode to a Prusa MK4 via PrusaLink. All demo commands below also run cleanly in **stub mode** without any hardware.
 
 ## UC1: Pipette a 96-Well Plate
 


### PR DESCRIPTION
## Summary

- Update \`docs/demo-scenarios.md\` reference from \`../app/hardware/README.md\` → \`../src/hardware/README.md\`
- Anchor \`#dpette-8-channel-mount-replaces-so-101-gripper-jaws\` matches existing heading at \`src/hardware/README.md:101\` unchanged

## Why

PR #95 renamed \`app/\` → \`src/\` but left this stale ref. Lychee resolves it as a \`file://\` path and fails on every PR, blocking 5 open dependabot PRs (#103–#107) on a non-code issue.

## Test plan

- [ ] \`linkChecker\` passes on this PR
- [ ] After merge, \`linkChecker\` turns green on #103–#107 (dependabot rebase or manual rerun)

Generated with Claude <noreply@anthropic.com>