### PR TITLE
feat: wire dPette USB driver as optional pipette dependency (#61)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ eln = [
 pylabrobot = [
     "pylabrobot>=0.2",
 ]
+pipette = [  # Electronic pipette driver (AELAB dPette 7016, DLAB dPette+)
+    "dpette",
+]
+
+[tool.uv.sources]
+dpette = { git = "https://github.com/Lambda-Biolab/dpette-usb-driver.git" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/so101", "src/dashboard"]

--- a/uv.lock
+++ b/uv.lock
@@ -480,6 +480,14 @@ wheels = [
 ]
 
 [[package]]
+name = "dpette"
+version = "0.2.0"
+source = { git = "https://github.com/Lambda-Biolab/dpette-usb-driver.git#41bea676d4cf95558818f5dc81fb97522d24c138" }
+dependencies = [
+    { name = "pyserial" },
+]
+
+[[package]]
 name = "draccus"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2392,6 +2400,9 @@ foxglove = [
 lerobot = [
     { name = "lerobot", extra = ["feetech"] },
 ]
+pipette = [
+    { name = "dpette" },
+]
 pylabrobot = [
     { name = "pylabrobot" },
 ]
@@ -2437,6 +2448,7 @@ foxglove = [
     { name = "yourdfpy" },
 ]
 lerobot = [{ name = "lerobot", extras = ["feetech"] }]
+pipette = [{ name = "dpette", git = "https://github.com/Lambda-Biolab/dpette-usb-driver.git" }]
 pylabrobot = [{ name = "pylabrobot", specifier = ">=0.2" }]
 test = [
     { name = "httpx", specifier = ">=0.27" },


### PR DESCRIPTION
## Summary

Adds `pipette` optional dependency group pointing at `Lambda-Biolab/dpette-usb-driver` via `[tool.uv.sources]`. Unblocks `ElectronicPipette`'s dpette driver resolution path.

`uv sync --group pipette` now installs the real driver; runtime auto-falls-back to stub mode when hardware is absent.

## What was already in place
The integration scaffold in `src/so101/pipette.py::ElectronicPipette` (imports from `dpette.config` and `dpette.driver`, graceful stub fallback). Only the dependency declaration was missing.

## Rationale for `[tool.uv.sources]` over `.gitmodules`
Driver is an independent library we consume, not co-developed source. `uv.lock` pins the commit reproducibly; one-step install via `uv sync`.

## Test plan
- [x] `uv sync --group pipette` resolves and installs dpette
- [x] `uv run pytest` — 323 tests pass
- [ ] Live hardware test with dPette+ attached (manual, hardware required)

## Closes
- #61

Generated with Claude <noreply@anthropic.com>