### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.claude/skills/creating-pr-from-branch/SKILL.md
+++ b/.claude/skills/creating-pr-from-branch/SKILL.md
@@ -42,9 +42,9 @@ its sections. If not, use this minimal format:
 ## Commits
 
 <list commits from git log>
-```
+```bash
 
-**Body guidelines:**
+### Body guidelines:
 - Fill template checkboxes where applicable (check items that are done)
 - Include `Closes #N` if the branch name contains an issue number
 - Keep it concise — the diff speaks for itself

--- a/.claude/skills/designing-backend/SKILL.md
+++ b/.claude/skills/designing-backend/SKILL.md
@@ -12,12 +12,14 @@ metadata:
   last-verified-cc-version: 1.0.34
 ---
 
+# Skill
+
 ## Git Context
 
 - Recent changes: !`git log --oneline -3`
 - Current branch: !`git branch --show-current`
 
-# Backend Architecture
+## Backend Architecture
 
 **Target**: $ARGUMENTS
 

--- a/.claude/skills/enforcing-doc-hierarchy/SKILL.md
+++ b/.claude/skills/enforcing-doc-hierarchy/SKILL.md
@@ -70,7 +70,7 @@ Detect violations across the scope. For each finding, record:
 
    **a) If `markdownlint-cli` is available** (`npx markdownlint-cli --version`
    succeeds): run it with the project config and parse output:
-   ```
+   ```text
    npx markdownlint-cli -c .markdownlint.json <scope> 2>&1
    ```
    Map results to violation types: MD012 → double blanks (fix during align),

--- a/.claude/skills/generating-tech-spec/SKILL.md
+++ b/.claude/skills/generating-tech-spec/SKILL.md
@@ -45,7 +45,7 @@ Read these before proceeding:
 
 ## Output Naming
 
-```
+```yaml
 ADR:      docs/adr/NNNN-<slug>.md        (e.g., 0003-use-event-sourcing.md)
 RFC:      docs/rfc/NNNN-<slug>.md        (e.g., 0001-api-versioning.md)
 Design:   docs/specs/<date>-<slug>.md    (e.g., 2026-03-01-auth-redesign.md)

--- a/.claude/skills/hardening-codebase/references/lint-tightening-checklist.md
+++ b/.claude/skills/hardening-codebase/references/lint-tightening-checklist.md
@@ -77,7 +77,7 @@ Tighten one level at a time. Fix violations before tightening further.
 
 Every project needs two recipes:
 
-```
+```text
 autofix    — format + lint --fix (developer convenience)
 lint       — format --check + lint (CI gate, fails on issues)
 complexity — cognitive complexity check (gate, fails above threshold)

--- a/.claude/skills/hardening-codebase/references/review-agents.md
+++ b/.claude/skills/hardening-codebase/references/review-agents.md
@@ -5,7 +5,7 @@ list as context to each.
 
 ## Agent 1: Code Reuse
 
-```
+```yaml
 Review changed files for CODE REUSE issues.
 
 For each change:
@@ -21,7 +21,7 @@ Report: file, issue, suggested fix. No false positives.
 
 ## Agent 2: Code Quality
 
-```
+```yaml
 Review changed files for CODE QUALITY issues.
 
 Look for:
@@ -37,7 +37,7 @@ Report: file, issue, suggested fix. Skip false positives.
 
 ## Agent 3: Efficiency
 
-```
+```yaml
 Review changed files for EFFICIENCY issues.
 
 Look for:

--- a/.claude/skills/testing-tdd/SKILL.md
+++ b/.claude/skills/testing-tdd/SKILL.md
@@ -33,7 +33,7 @@ Writes **focused, behavior-driven tests** following the TDD Red-Green-Refactor c
 
 Every test has three phases:
 
-```
+```text
 ARRANGE — Set up test data and dependencies
 ACT     — Execute the behavior under test
 ASSERT  — Verify the outcome

--- a/.claude/skills/testing-tdd/references/tdd-best-practices.md
+++ b/.claude/skills/testing-tdd/references/tdd-best-practices.md
@@ -5,6 +5,8 @@ based-on: Industry research 2025-2026, adapted from python-dev testing-python
 see-also: testing-strategy.md
 ---
 
+# TDD Best Practices
+
 **Purpose**: How to do TDD — Red-Green-Refactor cycle, AAA structure,
 best practices, anti-patterns. Language-agnostic.
 
@@ -29,7 +31,7 @@ best practices, anti-patterns. Language-agnostic.
 └─────┬───────┘
       │
       └──────> Repeat
-```
+```bash
 
 ## Core Practices
 
@@ -54,7 +56,7 @@ total = processor.calculateTotal(items)
 
 // ASSERT — Verify the outcome
 assertEqual(total, 25)
-```
+```text
 
 ### 3. Keep Tests Atomic and Isolated
 
@@ -90,7 +92,7 @@ assert(service._internalClient instanceof SomeLibrary)
 
 // GOOD — Tests behavior
 assertEqual(service.fetch("key"), expectedValue)
-```
+```text
 
 ### Untyped mocks
 

--- a/.claude/skills/testing-tdd/references/testing-strategy.md
+++ b/.claude/skills/testing-tdd/references/testing-strategy.md
@@ -6,6 +6,8 @@ purpose: High-level testing strategy aligned with KISS/DRY/YAGNI
 see-also: tdd-best-practices.md
 ---
 
+# Testing Strategy
+
 **Purpose**: What to test, test organization, mocking strategy,
 decision checklist. Language-agnostic.
 
@@ -87,7 +89,7 @@ decision checklist. Language-agnostic.
 tests/
 ├── *.test.*           # Unit tests
 └── setup.*            # Shared setup
-```
+```text
 
 **Organized structure** (larger projects):
 
@@ -102,7 +104,7 @@ tests/
 
 Name describes behavior, not method:
 
-```
+```text
 // Unit tests
 "calculates total from items"
 "returns empty array for unknown user"

--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>