### PR TITLE
chore: remove no-op start_teleoperation stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versi
 
 ## [Unreleased]
 
+### Removed
+
+- `DualArmController.start_teleoperation()` no-op stub from `src/so101/arms.py`. The method only validated inputs and logged `(stub)` — real teleop is invoked via `make start_teleop` / `lerobot-teleoperate`. Corresponding `TestTeleoperation` class removed from `tests/so101/test_arms.py`.
+
 ## [0.2.0] - 2026-04-16
 
 ### Added

--- a/src/so101/arms.py
+++ b/src/so101/arms.py
@@ -233,21 +233,6 @@ class DualArmController:
         for name in position_names:
             self.move_to_named(arm_id, name)
 
-    def start_teleoperation(self, follower_id: str) -> None:
-        """Start leader-follower teleoperation for an arm.
-
-        Args:
-            follower_id: Which follower arm to mirror the leader.
-
-        Raises:
-            ValueError: If no leader arm is configured or follower_id is unknown.
-        """
-        if self.config.leader is None:
-            raise ValueError("Leader arm not configured for teleoperation")
-        if follower_id not in self.arm_ids:
-            raise ValueError(f"Unknown arm: {follower_id}")
-        logger.info("Teleoperation: leader → %s (stub)", follower_id)
-
     def park_all(self) -> None:
         """Move all follower arms to the park (safe) position."""
         for arm_id in self.arm_ids:

--- a/tests/so101/test_arms.py
+++ b/tests/so101/test_arms.py
@@ -316,31 +316,3 @@ class TestErrorRecovery:
         assert ctrl.get_observation("arm_a")["history"] == []
 
 
-class TestTeleoperation:
-    """Teleoperation skeleton — deferred implementation."""
-
-    def test_teleoperate_requires_leader(self) -> None:
-        """start_teleoperation raises if no leader arm configured."""
-        config = DualArmConfig(
-            arm_a=ArmConfig(arm_id="arm_a", port="/dev/null", role="follower"),
-            arm_b=ArmConfig(arm_id="arm_b", port="/dev/null", role="follower"),
-            leader=None,
-            positions={"park": [0.0, -45.0, -90.0, 0.0, 0.0, 0.0]},
-        )
-        ctrl = DualArmController(config)
-        ctrl.connect()
-        with pytest.raises(ValueError, match=r"[Ll]eader"):
-            ctrl.start_teleoperation("arm_a")
-
-    def test_teleoperate_with_leader(self) -> None:
-        """start_teleoperation succeeds when leader arm is configured."""
-        config = DualArmConfig(
-            arm_a=ArmConfig(arm_id="arm_a", port="/dev/null", role="follower"),
-            arm_b=ArmConfig(arm_id="arm_b", port="/dev/null", role="follower"),
-            leader=ArmConfig(arm_id="leader", port="/dev/null", role="leader"),
-            positions={"park": [0.0, -45.0, -90.0, 0.0, 0.0, 0.0]},
-        )
-        ctrl = DualArmController(config)
-        ctrl.connect()
-        # Should not raise — stub mode just logs
-        ctrl.start_teleoperation("arm_a")


### PR DESCRIPTION
## Summary

Remove `DualArmController.start_teleoperation()` from `src/so101/arms.py`. The method only validated inputs and logged `(stub)`; the actual teleop loop lives in the external `lerobot-teleoperate` CLI invoked by `make start_teleop`.

A Python caller seeing the method reasonably expects it to start teleop, but it returns `None` on a successful no-op exactly like a working implementation would. Removing it before a future contributor mistakenly routes the dashboard `run_workflow` WebSocket command into it.

## Changes

- `src/so101/arms.py` — delete `start_teleoperation()` (~14 lines)
- `tests/so101/test_arms.py` — delete `TestTeleoperation` class (~28 lines) which covered only the stub
- `CHANGELOG.md` — record under `[Unreleased] > Removed`

## Test plan

- [ ] `uv run pytest tests/so101/test_arms.py` passes (no other test references `start_teleoperation`)
- [ ] `uv run pyright src tests` clean
- [ ] No remaining references: `grep -r start_teleoperation src tests` returns nothing

## Future work (out of scope)

If a Python-side teleop entry point is needed later (e.g. dashboard programmatic start/stop), two paths:

- subprocess wrapper around `lerobot-teleoperate`
- native loop using lerobot's Python API (supports custom safety / observation hooks)

Generated with Claude — Co-Authored-By trailer in the commit.