### PR TITLE
fix: hardware bringup ergonomics for partial setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- **Hardware bringup ergonomics for partial setups**:
+  - Per-arm calibrate targets `calibrate_arm_a`, `calibrate_arm_b`, `calibrate_leader` — 2-arm setups (leader + one follower) can calibrate only what is connected (Makefile)
+  - `CAMERAS` variable so `start_teleop` / `record_episodes` can run headless: `make start_teleop CAMERAS="{}"` (Makefile)
+  - Hardware bringup section in README Quick Start: `setup_hardware → find_port → install_udev → bringup → calibrate_arms`
+  - Pre-flight info block in `make bringup` output (find_port / install_udev / port env vars)
+  - `docs/hardware/bringup.md` §6 and §7 now surface per-arm and CAMERAS hints
+  - `CONTRIBUTING.md` make-command table annotates `calibrate_arms`, `start_teleop`, `record_episodes` with the new alternatives
+
+### Changed
+
+- **`setup_hardware` Makefile target**: tries PyPI wheels first via `uv sync --group lerobot --group foxglove`; falls back to `setup_hardware_deps` (sudo system build deps) only if wheel install fails. Removes blanket sudo prompt on first install.
+- **`lerobot-*` CLIs invoked via `uv run`**: `find_port`, `calibrate_arm_*`, `start_teleop`, `record_episodes`, `train_policy` no longer require manual `source .venv/bin/activate` (fixes `lerobot-find-port: command not found`)
+- **`.PHONY`** expanded to cover all hardware + per-arm targets
+
 ### Removed
 
 - `DualArmController.start_teleoperation()` no-op stub from `src/so101/arms.py`. The method only validated inputs and logged `(stub)` — real teleop is invoked via `make start_teleop` / `lerobot-teleoperate`. Corresponding `TestTeleoperation` class removed from `tests/so101/test_arms.py`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ For AI agent behavioral rules, see [AGENTS.md](AGENTS.md).
 | `make validate` | Full gate (lint + types + tests + coverage + complexity) |
 | `make quick_validate` | Fast development validation (lint + type check) |
 | `make test` | Run all non-hardware tests with pytest |
-| `make calibrate_arms` | Calibrate all arms |
-| `make start_teleop` | Start teleoperation |
-| `make record_episodes` | Record training episodes |
+| `make calibrate_arms` | Calibrate all arms (or per-arm: `calibrate_arm_a`, `calibrate_arm_b`, `calibrate_leader` for partial setups) |
+| `make start_teleop` | Start teleoperation (override `CAMERAS="{}"` for headless / no-camera setups) |
+| `make record_episodes` | Record training episodes (same `CAMERAS="{}"` override) |
 | `make train_policy` | Train ACT policy |
 | `make serve_dashboard` | Start remote dashboard |
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ endif
 	setup_uv setup_dev setup_all setup_cad setup_scad setup_slicer setup_node setup_rtk setup_lychee setup_mdlint setup_diagramforge setup_hardware_deps setup_hardware \
 	render_parts check_prints render_all \
 	autofix lint check_links check_docs check_types check_complexity test test_cov retest quick_validate validate \
-	calibrate_arms start_teleop start_foxglove fetch_urdf record_episodes train_policy \
+	find_port scan_servos install_udev bringup patch_lerobot patch_lerobot_revert \
+	calibrate_arms calibrate_arm_a calibrate_arm_b calibrate_leader \
+	start_teleop start_foxglove fetch_urdf record_episodes train_policy \
 	eval_policy serve_dashboard run_demo \
 	help
 .DEFAULT_GOAL := help
@@ -45,6 +47,7 @@ POLICY ?= act
 WANDB ?= 0
 WRIST_CAM ?= 2
 ENV_CAM ?= 0
+CAMERAS ?= { overhead: {type: opencv, index_or_path: $(ENV_CAM), width: 640, height: 480, fps: 30}, wrist: {type: opencv, index_or_path: $(WRIST_CAM), width: 640, height: 480, fps: 30}}
 
 # Detect OS and package manager — use in recipes via $(DETECT_PKG_MGR)
 # Sets: PKG_MGR (dnf|apt|pacman|brew), HOST_OS (linux|darwin), HOST_ARCH (x86_64|aarch64|arm64)
@@ -219,8 +222,26 @@ setup_hardware_deps: ## Install system deps for lerobot (kernel headers, cmake, 
 		*) echo "ERROR: unsupported package manager — install kernel headers, cmake, and libav dev packages manually"; exit 1 ;;
 	esac
 
-setup_hardware: setup_uv setup_hardware_deps ## Install all hardware deps (LeRobot, Feetech, Foxglove, system libs)
-	uv sync --group lerobot --group foxglove
+setup_hardware: setup_uv ## Install hardware deps; tries PyPI wheels, falls back to building from source
+	echo "Installing lerobot + foxglove from PyPI wheels (no sudo) ..."
+	if uv sync --group lerobot --group foxglove; then
+		echo "OK: installed from wheels — no system build deps required"
+	else
+		echo ""
+		echo "Wheel install failed — some packages need to build from source."
+		echo "This requires system build deps (sudo will be requested)."
+		echo "Falling back to: make setup_hardware_deps + retry uv sync"
+		echo ""
+		$(MAKE) setup_hardware_deps
+		if ! uv sync --group lerobot --group foxglove; then
+			echo ""
+			echo "ERROR: install still failing after system build deps installed."
+			echo "Re-run with verbose output for details:"
+			echo "  uv sync --group lerobot --group foxglove -v"
+			exit 1
+		fi
+		echo "OK: installed from source after system deps"
+	fi
 
 
 # MARK: HARDWARE
@@ -235,7 +256,7 @@ check_prints: ## Run slicer printability checks on STLs (CuraEngine or PrusaSlic
 render_all: render_parts check_prints ## Generate parts + validate printability
 
 find_port: ## Identify serial port for a single board (unplug USB when prompted)
-	lerobot-find-port
+	uv run lerobot-find-port
 
 scan_servos: ## Scan a port for STS3215 servos (override: PORT=/dev/ttyACM1)
 	uv run so101-scan-servos --port=$(or $(PORT),/dev/ttyACM0)
@@ -247,24 +268,35 @@ install_udev: ## Install udev rule for Waveshare boards (makes ttyACM* world-rw)
 	sudo udevadm trigger
 	echo "udev rule installed. Replug the Waveshare board(s)."
 
-bringup: patch_lerobot scan_servos ## Guided first-bringup: patch lerobot + scan servos
+bringup: patch_lerobot scan_servos ## Patch lerobot + scan servos (run after find_port & install_udev)
+	echo ""
+	echo "Before running 'make bringup':"
+	echo "  - 'make find_port' to identify each /dev/ttyACM* (unplug one board at a time)."
+	echo "  - 'make install_udev' once if /dev/ttyACM* gives permission errors."
+	echo "  - Set LEADER_PORT / FOLLOWER_A_PORT / FOLLOWER_B_PORT to match find_port output."
 	echo ""
 	echo "Next steps:"
 	echo "  1. If scan shows mixed firmware, patches are already applied."
 	echo "  2. Run 'make calibrate_arms' (or calibrate individually)."
 	echo "  3. Run 'make start_teleop' to verify leader → follower."
 
-calibrate_arms: ## Calibrate all arms (leader + followers)
-	lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_A_PORT) --robot.id=arm_a
-	lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_B_PORT) --robot.id=arm_b
-	lerobot-calibrate --teleop.type=so101_leader --teleop.port=$(LEADER_PORT) --teleop.id=leader
+calibrate_arm_a: ## Calibrate follower A only
+	uv run lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_A_PORT) --robot.id=arm_a
 
-start_teleop: ## Start teleoperation (leader → follower)
-	lerobot-teleoperate \
+calibrate_arm_b: ## Calibrate follower B only
+	uv run lerobot-calibrate --robot.type=so101_follower --robot.port=$(FOLLOWER_B_PORT) --robot.id=arm_b
+
+calibrate_leader: ## Calibrate leader only
+	uv run lerobot-calibrate --teleop.type=so101_leader --teleop.port=$(LEADER_PORT) --teleop.id=leader
+
+calibrate_arms: calibrate_arm_a calibrate_arm_b calibrate_leader ## Calibrate all arms (leader + both followers)
+
+start_teleop: ## Start teleoperation (leader → follower); CAMERAS="{}" to disable cameras
+	uv run lerobot-teleoperate \
 		--robot.type=so101_follower \
 		--robot.port=$(FOLLOWER_A_PORT) \
 		--robot.id=arm_a \
-		--robot.cameras="{ overhead: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}, wrist: {type: opencv, index_or_path: 2, width: 640, height: 480, fps: 30}}" \
+		--robot.cameras="$(CAMERAS)" \
 		--teleop.type=so101_leader \
 		--teleop.port=$(LEADER_PORT) \
 		--teleop.id=leader \
@@ -292,12 +324,12 @@ start_foxglove: fetch_urdf ## Live 3D arm viz + cameras via Foxglove (ws://local
 		--robot.wrist_cam_id=$(WRIST_CAM) \
 		--robot.env_cam_id=$(ENV_CAM)
 
-record_episodes: ## Record teleoperation episodes
-	lerobot-record \
+record_episodes: ## Record teleoperation episodes; CAMERAS="{}" to disable cameras
+	uv run lerobot-record \
 		--robot.type=so101_follower \
 		--robot.port=$(FOLLOWER_A_PORT) \
 		--robot.id=arm_a \
-		--robot.cameras="{ overhead: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}, wrist: {type: opencv, index_or_path: 2, width: 640, height: 480, fps: 30}}" \
+		--robot.cameras="$(CAMERAS)" \
 		--teleop.type=so101_leader \
 		--teleop.port=$(LEADER_PORT) \
 		--teleop.id=leader \
@@ -308,7 +340,7 @@ record_episodes: ## Record teleoperation episodes
 		--display_data=true
 
 train_policy: ## Train policy on recorded data (WANDB=1 to enable wandb)
-	lerobot-train \
+	uv run lerobot-train \
 		--dataset.repo_id=$(DATASET) \
 		--policy.type=$(POLICY) \
 		--output_dir=outputs/train/$(POLICY)_biolab \

--- a/README.md
+++ b/README.md
@@ -40,11 +40,29 @@ make render_parts
 make setup_slicer
 make check_prints
 
-# Calibrate arms
-make calibrate_arms
+# --- Hardware bringup (one-time) ---
+
+# Install LeRobot deps (PyPI wheels first; falls back to build-from-source if needed)
+make setup_hardware
+
+# Identify USB serial ports for each board (unplug one at a time when prompted)
+make find_port
+
+# Fix /dev/ttyACM* permissions (one-time; replug boards after)
+make install_udev
+
+# Scan servos + patch lerobot for mixed STS3215 firmware
+make bringup PORT=/dev/ttyACM1
+
+# Calibrate arms (move each through its full range when prompted)
+make calibrate_arms                       # full 3-arm setup (leader + arm_a + arm_b)
+# for 2-arm setups (leader + one follower) run only what is connected:
+# make calibrate_arm_a calibrate_leader
 
 # Teleoperate (teacher-student)
-make start_teleop
+make start_teleop                         # uses cameras by default
+# or headless (no cameras):
+# make start_teleop CAMERAS="{}"
 
 # Record pipetting episodes
 make record_episodes TASK="pipette row A"

--- a/docs/hardware/bringup.md
+++ b/docs/hardware/bringup.md
@@ -207,7 +207,9 @@ uv run lerobot-calibrate \
 Or use the Makefile target (calibrates all three sequentially):
 
 ```bash
-make calibrate_arms
+make calibrate_arms                       # all three (leader + both followers)
+# for 2-arm setups (leader + one follower) calibrate only what is connected:
+# make calibrate_arm_a calibrate_leader
 ```
 
 ## 7. Teleoperation Test (Grippers)
@@ -240,7 +242,9 @@ uv run lerobot-teleoperate \
 Or via Makefile:
 
 ```bash
-make start_teleop
+make start_teleop                         # uses cameras by default
+# headless (no cameras):
+# make start_teleop CAMERAS="{}"
 ```
 
 Verify the follower arm mirrors the leader's movements.


### PR DESCRIPTION
## Summary

Carries the rough edges of fresh hardware bringup back into the Makefile and docs so contributors with 2-arm setups, headless rigs, or no system build deps don't hit dead ends on first run.

## Why

Bringing up a fresh SO-101 setup hit three blockers in sequence:

1. `make find_port` → `lerobot-find-port: command not found` (the CLI lives in `.venv/` but the recipes call it bare)
2. `make calibrate_arms` → silently skipped arms with missing ports (no `set -e`), but a 2-arm user can't tell
3. `make start_teleop` → `OpenCVCamera(2) connection failed` for headless rigs (camera config hard-coded)
4. `make setup_hardware` → blanket sudo prompt even when PyPI wheels were available

This PR resolves all four with sensible defaults preserved.

## Makefile changes

- **`uv run` prefix** on all `lerobot-*` CLI invocations: `find_port`, `calibrate_arm_*`, `start_teleop`, `record_episodes`, `train_policy`. No more manual venv activation.
- **`setup_hardware` wheel-first**: try `uv sync --group lerobot --group foxglove`; only invoke `setup_hardware_deps` (sudo) if wheel install fails. Graceful error message if the fallback also fails.
- **Per-arm calibrate targets**: `calibrate_arm_a`, `calibrate_arm_b`, `calibrate_leader` — `calibrate_arms` becomes an aggregate. Partial-hardware setups can run only what is connected.
- **`CAMERAS` variable**: overridable via `make start_teleop CAMERAS="{}"` to disable cameras for headless setups. Default preserves the existing overhead + wrist config.
- **`bringup` pre-flight echo**: prints `find_port`, `install_udev`, and port-env-var guidance before the existing post-step next-actions.
- **`.PHONY` expanded** to cover all hardware + per-arm targets.

## Docs propagation

- README Quick Start: new `Hardware bringup (one-time)` section between print-validation and calibrate_arms; inline per-arm + CAMERAS hints near the calibrate/teleop lines.
- `docs/hardware/bringup.md` §6 and §7: same alternatives so the deep guide and README stay in sync.
- CONTRIBUTING.md make-command table: annotate `calibrate_arms`, `start_teleop`, `record_episodes` rows.
- CHANGELOG.md: new `[Unreleased] > Added` and `[Unreleased] > Changed` entries.

## Test plan

- [ ] `make help` lists the new targets (`calibrate_arm_a`, `calibrate_arm_b`, `calibrate_leader`)
- [ ] `make setup_hardware` succeeds without sudo when wheels are available
- [ ] `make find_port` works without manual `source .venv/bin/activate`
- [ ] `make calibrate_arm_a` calibrates only follower A
- [ ] `make start_teleop CAMERAS="{}"` runs without opening any camera
- [ ] `make bringup` prints pre-flight info before patching/scanning
- [ ] README Quick Start is end-to-end followable on a fresh machine
- [ ] CI green (CodeQL, ruff, pytest, lychee, markdownlint)

## Out of scope

- Free-drive both-arms mode (torque-off teleop without a leader)
- Foxglove + Rerun live-viz on-hardware validation

Generated with Claude — Co-Authored-By trailer in the commit.