### PR TITLE
feat(make): expose FOXGLOVE_CAM_FLAGS to run start_foxglove headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versi
 
 ### Added
 
+- **`FOXGLOVE_CAM_FLAGS` Makefile variable**: parallels `CAMERAS` for the foxglove path. Override with `make start_foxglove FOXGLOVE_CAM_FLAGS=""` to run headless. `foxglove_viz.py` already supports this (camera flags are optional in argparse; `_try_camera(None, ...)` returns early).
 - **Live Visualization section** in README: collapsible `<details>` block with annotated Rerun.io screenshot (`assets/images/screenshot_rerun.io_so101.png`) showing joint time-series, observation streams, recording metadata, and blueprint panels. Notes `make start_foxglove` for the separate 3D + camera view.
 - **`TODO:` comments** in Makefile above `start_teleop`, `record_episodes`, and `start_foxglove` marking the live-viz layer as partially validated (Rerun joint streams confirmed; Rerun camera path and Foxglove local+remote unverified on hardware).
 - **Hardware bringup ergonomics for partial setups**:
@@ -18,6 +19,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versi
 
 ### Changed
 
+- **`make start_foxglove`** no longer hard-codes camera flags inline — references the new `FOXGLOVE_CAM_FLAGS` variable instead, matching the `CAMERAS` pattern used by `start_teleop` / `record_episodes`.
 - **`setup_hardware` Makefile target**: tries PyPI wheels first via `uv sync --group lerobot --group foxglove`; falls back to `setup_hardware_deps` (sudo system build deps) only if wheel install fails. Removes blanket sudo prompt on first install.
 - **`lerobot-*` CLIs invoked via `uv run`**: `find_port`, `calibrate_arm_*`, `start_teleop`, `record_episodes`, `train_policy` no longer require manual `source .venv/bin/activate` (fixes `lerobot-find-port: command not found`)
 - **`.PHONY`** expanded to cover all hardware + per-arm targets

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ WANDB ?= 0
 WRIST_CAM ?= 2
 ENV_CAM ?= 0
 CAMERAS ?= { overhead: {type: opencv, index_or_path: $(ENV_CAM), width: 640, height: 480, fps: 30}, wrist: {type: opencv, index_or_path: $(WRIST_CAM), width: 640, height: 480, fps: 30}}
+FOXGLOVE_CAM_FLAGS ?= --robot.wrist_cam_id=$(WRIST_CAM) --robot.env_cam_id=$(ENV_CAM)
 
 # Detect OS and package manager — use in recipes via $(DETECT_PKG_MGR)
 # Sets: PKG_MGR (dnf|apt|pacman|brew), HOST_OS (linux|darwin), HOST_ARCH (x86_64|aarch64|arm64)
@@ -318,13 +319,12 @@ fetch_urdf: ## Download SO-101 URDF + STL assets from foxglove-sdk
 	fi
 
 # TODO: Foxglove live 3D viz unvalidated on hardware (local + remote)
-start_foxglove: fetch_urdf ## Live 3D arm viz + cameras via Foxglove (ws://localhost:8765)
+start_foxglove: fetch_urdf ## Live 3D arm viz via Foxglove (ws://localhost:8765); FOXGLOVE_CAM_FLAGS="" to disable cameras
 	@echo "Requires: uv sync --group foxglove --group lerobot"
 	uv run --group foxglove --group lerobot so101-foxglove \
 		--robot.port=$(FOLLOWER_A_PORT) \
 		--robot.id=arm_a \
-		--robot.wrist_cam_id=$(WRIST_CAM) \
-		--robot.env_cam_id=$(ENV_CAM)
+		$(FOXGLOVE_CAM_FLAGS)
 
 # TODO: Rerun.io live viz (via --display_data=true) unvalidated on hardware — joint streams confirmed, camera path unverified
 record_episodes: ## Record teleoperation episodes; CAMERAS="{}" to disable cameras


### PR DESCRIPTION
## Summary

Mirrors the `CAMERAS` pattern added for `start_teleop` / `record_episodes` in #145. The `make start_foxglove` recipe hard-coded `--robot.wrist_cam_id` / `--robot.env_cam_id` flags, so a headless rig (no cameras) couldn't run the foxglove viz without editing the Makefile.

## Key observation

`src/so101/cli/foxglove_viz.py` **already supports the headless path** — both camera flags are optional in argparse, and `_try_camera(None, ...)` returns early without attempting to open a device. The only blocker was the Makefile always passing the flags.

No Python change needed.

## Changes (Makefile only + CHANGELOG)

- New variable in the config section:

  ```makefile
  FOXGLOVE_CAM_FLAGS ?= --robot.wrist_cam_id=$(WRIST_CAM) --robot.env_cam_id=$(ENV_CAM)
  ```

  Default value preserves current behaviour.

- `start_foxglove` recipe references `$(FOXGLOVE_CAM_FLAGS)` instead of inlining the flags.

- Help text updated:

  ```makefile
  start_foxglove: fetch_urdf ## Live 3D arm viz via Foxglove (ws://localhost:8765); FOXGLOVE_CAM_FLAGS="" to disable cameras
  ```

- CHANGELOG: entries under `[Unreleased] > Added` and `[Unreleased] > Changed`.

## Usage

```bash
make start_foxglove                        # with cameras (default)
make start_foxglove FOXGLOVE_CAM_FLAGS=""   # headless
make start_foxglove WRIST_CAM=4 ENV_CAM=2   # different camera indices
```

## Test plan

- [ ] `make help` shows the updated `start_foxglove` row with the new override note
- [ ] `grep FOXGLOVE_CAM_FLAGS Makefile` shows both the variable declaration and the recipe reference
- [ ] `make start_foxglove FOXGLOVE_CAM_FLAGS=""` invokes `so101-foxglove` without camera flags (manual smoke test on user's hardware)
- [ ] CI green (CodeQL, ruff, pytest, lychee, markdownlint, complexipy)

## Why this matters

Closes the foxglove-side symmetry gap with `CAMERAS` (from #145). A 2-arm setup with no cameras (the most common minimal hardware config) can now run both `make start_teleop CAMERAS="{}"` and `make start_foxglove FOXGLOVE_CAM_FLAGS=""` end-to-end without editing recipes.

Generated with Claude — Co-Authored-By trailer in the commit.