### PR TITLE
fix(ci): grant issues:write to unblock lint-md-links startup_failure

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write  # required at workflow startup by reusable notify job (even when unused)
 
 jobs:
   lint:


### PR DESCRIPTION
Fix `Lint MD and Links` workflow startup_failure caused by missing `issues: write` grant. The upstream reusable's `notify` job declares `permissions: issues: write`; GitHub validates all reusable-job permissions at workflow startup, before `if:` conditions are evaluated. Even with `notify_on_failure: false` (default), callers must grant `issues: write` or every run fails at startup.

Reference: [qte77/.github#26](https://github.com/qte77/.github/pull/26) (docs explaining the constraint).

## Test plan

- [ ] CI: `Lint MD and Links` workflow reaches `markdown` + `links` jobs (not `startup_failure`); `notify` job is correctly SKIPPED.