### PR TITLE
style+ci: fix ruff format drift, adopt push-based CodeQL (#167)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,9 +3,6 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     - cron: "27 11 * * 0"
   workflow_dispatch:
@@ -31,4 +28,14 @@ jobs:
       - name: Autobuild
         uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
       - name: Perform CodeQL Analysis
+        id: analyze
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          output: sarif-results
+      - name: Dismiss suppressed alerts
+        uses: advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e  # v2.0.2
+        with:
+          sarif-id: ${{ steps.analyze.outputs.sarif-id }}
+          sarif-file: sarif-results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/so101/cli/foxglove_viz.py
+++ b/src/so101/cli/foxglove_viz.py
@@ -89,8 +89,11 @@ def _publish_frame(camera: Any, channel: Any) -> None:
 
 
 _JOINT_KEYS = [
-    "shoulder_pan", "shoulder_lift", "elbow_flex",
-    "wrist_flex", "wrist_roll",
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
 ]
 
 
@@ -116,7 +119,8 @@ def _build_transforms(robot_model: Any) -> list[Any]:
     ]
     for joint in robot_model.robot.joints:
         t_local = robot_model.get_transform(
-            frame_to=joint.child, frame_from=joint.parent,
+            frame_to=joint.child,
+            frame_from=joint.parent,
         )
         trans = t_local[:3, 3]
         quat = Rotation.from_matrix(t_local[:3, :3]).as_quat()
@@ -125,11 +129,15 @@ def _build_transforms(robot_model: Any) -> list[Any]:
                 parent_frame_id=joint.parent,
                 child_frame_id=joint.child,
                 translation=Vector3(
-                    x=float(trans[0]), y=float(trans[1]), z=float(trans[2]),
+                    x=float(trans[0]),
+                    y=float(trans[1]),
+                    z=float(trans[2]),
                 ),
                 rotation=Quaternion(
-                    x=float(quat[0]), y=float(quat[1]),
-                    z=float(quat[2]), w=float(quat[3]),
+                    x=float(quat[0]),
+                    y=float(quat[1]),
+                    z=float(quat[2]),
+                    w=float(quat[3]),
                 ),
             ),
         )

--- a/src/so101/cli/patch_lerobot.py
+++ b/src/so101/cli/patch_lerobot.py
@@ -38,7 +38,7 @@ MOTORS_BUS_PY = SITE_PACKAGES / "motors_bus.py"
 
 # --- Patch 1: firmware version check ---
 
-FW_ORIGINAL = '''\
+FW_ORIGINAL = """\
     def _assert_same_firmware(self) -> None:
         firmware_versions = self._read_firmware_version(self.ids, raise_on_error=True)
         if len(set(firmware_versions.values())) != 1:
@@ -47,9 +47,9 @@ FW_ORIGINAL = '''\
                 f"\\n{pformat(firmware_versions)}\\n"
                 "Update their firmware first using Feetech's software. "
                 "Visit https://www.feetechrc.com/software."
-            )'''
+            )"""
 
-FW_PATCHED = '''\
+FW_PATCHED = """\
     def _assert_same_firmware(self) -> None:
         firmware_versions = self._read_firmware_version(self.ids, raise_on_error=True)
         if len(set(firmware_versions.values())) != 1:
@@ -58,11 +58,11 @@ FW_PATCHED = '''\
                 "Mixed firmware versions detected (PATCHED — continuing anyway):"
                 f"\\n{pformat(firmware_versions)}\\n"
                 "For production use, update firmware via Feetech FD software."
-            )'''
+            )"""
 
 # --- Patch 2: sync_read fallback to sequential reads ---
 
-SYNC_ORIGINAL = '''\
+SYNC_ORIGINAL = """\
     def _sync_read(
         self,
         addr: int,
@@ -87,9 +87,9 @@ SYNC_ORIGINAL = '''\
             raise ConnectionError(f"{err_msg} {self.packet_handler.getTxRxResult(comm)}")
 
         values = {id_: self.sync_reader.getData(id_, addr, length) for id_ in motor_ids}
-        return values, comm'''
+        return values, comm"""
 
-SYNC_PATCHED = '''\
+SYNC_PATCHED = """\
     _sync_read_warned = False  # PATCHED: suppress repeated warnings
 
     def _sync_read(
@@ -138,20 +138,20 @@ SYNC_PATCHED = '''\
             val = max(0, min(4095, val))
             values[motor_id] = val
             last_comm = c
-        return values, last_comm'''
+        return values, last_comm"""
 
 
 # --- Patch 3: clamp calibration range values before writing to servo EPROM ---
 
-CAL_ORIGINAL = '''\
+CAL_ORIGINAL = """\
     def write_calibration(self, calibration_dict: dict[str, MotorCalibration], cache: bool = True) -> None:
         for motor, calibration in calibration_dict.items():
             if self.protocol_version == 0:
                 self.write("Homing_Offset", motor, calibration.homing_offset)
             self.write("Min_Position_Limit", motor, calibration.range_min)
-            self.write("Max_Position_Limit", motor, calibration.range_max)'''
+            self.write("Max_Position_Limit", motor, calibration.range_max)"""
 
-CAL_PATCHED = '''\
+CAL_PATCHED = """\
     def write_calibration(self, calibration_dict: dict[str, MotorCalibration], cache: bool = True) -> None:
         for motor, calibration in calibration_dict.items():
             if self.protocol_version == 0:
@@ -160,7 +160,7 @@ CAL_PATCHED = '''\
             range_min = max(0, min(4095, calibration.range_min))
             range_max = max(0, min(4095, calibration.range_max))
             self.write("Min_Position_Limit", motor, range_min)
-            self.write("Max_Position_Limit", motor, range_max)'''
+            self.write("Max_Position_Limit", motor, range_max)"""
 
 
 def _apply_patch(path: Path, original: str, patched: str, name: str, *, revert: bool) -> bool:
@@ -198,7 +198,9 @@ def main() -> None:
 
     results = [
         _apply_patch(FEETECH_PY, FW_ORIGINAL, FW_PATCHED, "firmware_check", revert=revert),
-        _apply_patch(MOTORS_BUS_PY, SYNC_ORIGINAL, SYNC_PATCHED, "sync_read_fallback", revert=revert),
+        _apply_patch(
+            MOTORS_BUS_PY, SYNC_ORIGINAL, SYNC_PATCHED, "sync_read_fallback", revert=revert
+        ),
         _apply_patch(FEETECH_PY, CAL_ORIGINAL, CAL_PATCHED, "calibration_clamp", revert=revert),
     ]
 

--- a/src/so101/cli/scan_servos.py
+++ b/src/so101/cli/scan_servos.py
@@ -31,9 +31,7 @@ def scan(port_path: str, ids: range) -> list[tuple[int, int, str]]:
     try:
         from scservo_sdk import PacketHandler, PortHandler  # type: ignore[import-untyped]
     except ImportError as err:
-        raise RuntimeError(
-            "scservo_sdk not installed — run 'uv sync --group lerobot'"
-        ) from err
+        raise RuntimeError("scservo_sdk not installed — run 'uv sync --group lerobot'") from err
 
     port = PortHandler(port_path)
     if not port.openPort():

--- a/tests/so101/test_arms.py
+++ b/tests/so101/test_arms.py
@@ -314,5 +314,3 @@ class TestErrorRecovery:
 
         ctrl.connect()
         assert ctrl.get_observation("arm_a")["history"] == []
-
-


### PR DESCRIPTION
## Summary

Two scoped follow-ups from the dependabot-remediation review (#190), one commit per topic.

### 1. `style:` ruff format drift
`make validate`'s `lint` step (`ruff format --check`) was failing on 4 files that
had drifted out of format (pre-existing on `main`, unrelated to any feature). CI's
ruff job only runs `ruff check` (not `--check` format), so it slipped through.
Whitespace/formatting only — no logic changes.

- `src/so101/cli/foxglove_viz.py`, `src/so101/cli/patch_lerobot.py`,
  `src/so101/cli/scan_servos.py`, `tests/so101/test_arms.py`

### 2. `ci(codeql):` adopt push-based config (#167)
Implements the CodeQL deviations tracked in #167:

- Drop the `pull_request:` trigger and the `push: branches:[main]` filter — `push:`
  now scans every branch, eliminating the merge-ref SARIF race that intermittently
  blocked merges.
- Add `advanced-security/dismiss-alerts` (SHA-pinned) so inline `# codeql[...]`
  suppressions actually dismiss rather than reopen on each scan.

Addresses the **CodeQL half** of #167; the **Dependabot half** is in #190. Close
#167 once both land.

## Verification

- [x] `make validate` — **green**: lint clean (drift fixed), pyright 0 errors,
      321 passed / 1 skipped, coverage 80.05% ≥ 80%, complexity all pass.

## Note (not in this PR)

`main` has a pre-existing lockfile inconsistency: `scriv[toml]>=1.8` is in
`pyproject.toml`'s `test` group but absent from `uv.lock` (any `uv run` re-adds it).
Out of scope here — flagged for a separate `chore(deps)` sync.

Generated with Claude <noreply@anthropic.com>
