### PR TITLE
feat: AGENTS.md standard + scriv changelog tooling (WIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/), [Semantic Versioning](https://semver.org/).
 
+<!-- scriv-insert-here -->
+
 ## [Unreleased]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Insertions
-
-@AGENTS.md
+AGENTS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "opencv-stubs>=0.1.3",
 ]
 test = [
+    "scriv[toml]>=1.8",
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=6.0",
@@ -161,3 +162,11 @@ replace = """
 
 [tool.coverage.run]
 omit = ["src/so101/cli/foxglove_viz.py"]  # hardware CLI — requires real arms + cameras
+
+[tool.scriv]
+format = "md"
+fragment_directory = "changelog.d"
+categories = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+md_header_level = "2"
+entry_title_template = "[{{ version }}] - {{ date.strftime('%Y-%m-%d') }}"
+md_html_anchors = false


### PR DESCRIPTION
Draft — pushing the previously local-only WIP branch to the remote for backup and review (per cleanup review).

Contains commit 2dc1c09: scriv changelog tooling + CLAUDE.md→AGENTS.md symlink + AGENTS.md standard adoption.

**Not ready to merge.** May overlap with scriv changes already on main (the scriv lockfile sync landed via #197). Reconcile before un-drafting.

Generated with Claude <noreply@anthropic.com>