### PR TITLE
ci: ignore lerobot-capped deps + commit SBOM directly to main

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,6 +12,11 @@ updates:
     groups:
       python-deps:
         patterns: ["*"]
+    # torch/diffusers patched versions require downgrading lerobot 0.4.4 (breaks
+    # patch_lerobot.py). lerobot is pinned >=0.4.4; ignore these to avoid the trap.
+    ignore:
+      - dependency-name: "torch"
+      - dependency-name: "diffusers"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   generate-sbom:
@@ -23,4 +22,17 @@ jobs:
       - name: Generate SBOM
         uses: qte77/gha-sbom-action@f1aca6c93b91fa3f41060db5c9251fc2715e3c77 # v0.1.0
         with:
+          create_pr: "false"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit SBOM to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/SBOM
+          if git diff --cached --quiet; then
+            echo "SBOM unchanged — nothing to commit"
+          else
+            git commit -m "docs: update SBOM [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## Summary

Two CI/config follow-ups from the dependency-remediation cleanup.

### 1. `ci(dependabot):` ignore torch + diffusers
Their CVE-patched versions (torch 2.12.1, diffusers 0.38.0) only resolve by
downgrading lerobot 0.4.4 → 0.3.x, which breaks `patch_lerobot.py`. The 3 alerts are
dismissed as tolerable risk and `lerobot[feetech]>=0.4.4` is pinned; the `ignore` rule
keeps these out of version-update / grouped Dependabot PRs so the trap can't reappear.

### 2. `ci(sbom):` commit SBOM directly to main
The SBOM action opened a timestamped PR on every push to main, and branch protection
**blocks those docs-only PRs** (required code checks never run on them) — so they piled
up (6 open at peak). Switch to `create_pr: "false"` + commit `docs/SBOM` straight to
main with `[skip ci]`. `paths-ignore: docs/SBOM/**` already prevents the commit from
re-triggering the workflow. Drops the now-unused `pull-requests: write` permission.

> **Note:** the direct commit needs the `github-actions` bot to be allowed to push to
> `main`. If branch protection blocks it, either allow the bot to bypass for this path
> or fall back to schedule-only triggers.

## Verification

- [x] YAML valid; SHA-pinned actions unchanged
- [ ] After merge: confirm the SBOM commits directly to main (no new PR) and that
      Dependabot no longer opens torch/diffusers PRs

Once merged, the latest SBOM PR (#205) is superseded and will be closed.

Generated with Claude <noreply@anthropic.com>
