### PR TITLE
ci(sbom): make SBOM push tolerant of branch protection (no failed runs)

### DIFF
--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -34,5 +34,5 @@ jobs:
             echo "SBOM unchanged — nothing to commit"
           else
             git commit -m "docs: update SBOM [skip ci]"
-            git push
+            git push || echo "::warning::SBOM push rejected by branch protection. Allow the github-actions[bot] to bypass push restrictions on main to enable auto-commit."
           fi


### PR DESCRIPTION
Follow-up to #208. The direct-commit SBOM step fails at `git push` because branch protection rejects the github-actions[bot] push to main (confirmed: run 27845701862, 'Commit SBOM to main' step failed).

Makes the push non-fatal — emits a `::warning::` annotation instead of failing the run. Behaviour:
- **No PR pile-up** (still create_pr:false).
- **No red runs** per merge.
- **Auto-commits the SBOM the moment** the github-actions[bot] is allowed to bypass push restrictions on main (Settings → branch protection / ruleset) — no further code change.

Until that bypass is granted, the SBOM simply won't update (with a visible warning). Alternative if you prefer never to grant the bypass: switch to schedule-only PRs + admin-merge.

Generated with Claude <noreply@anthropic.com>